### PR TITLE
Parameterize server config and clean DB status

### DIFF
--- a/database.ts
+++ b/database.ts
@@ -30,8 +30,6 @@ export const dbConnectionStatus: DbConnectionStatus = {
     serverAvailable: false,
 };
 
-let isConnected = false;
-
 // Check server availability on startup
 async function checkServerAvailability() {
     try {
@@ -599,7 +597,7 @@ const db = {
         }
         
         return {
-            connected: isConnected,
+            connected: dbConnectionStatus.connected,
             indexedDBAvailable,
             storageStats,
             issues

--- a/lib/localServerClient.ts
+++ b/lib/localServerClient.ts
@@ -5,7 +5,7 @@
  * Reemplaza el almacenamiento en localStorage/IndexedDB por almacenamiento en servidor
  */
 
-const SERVER_URL = 'http://localhost:3001';
+const SERVER_URL = import.meta.env.VITE_SERVER_URL || 'http://localhost:3001';
 
 export class LocalServerClient {
     private baseUrl: string;

--- a/server.js
+++ b/server.js
@@ -24,7 +24,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const app = express();
-const PORT = 3001;
+const PORT = parseInt(process.env.PORT || '3001', 10);
+const BODY_LIMIT_MB = process.env.BODY_LIMIT_MB || '50mb';
 
 // Database setup
 const dbPath = join(__dirname, 'ver6_data.db');
@@ -32,8 +33,8 @@ const db = new Database(dbPath);
 
 // Middleware
 app.use(cors());
-app.use(express.json({ limit: '50mb' }));
-app.use(express.urlencoded({ extended: true, limit: '50mb' }));
+app.use(express.json({ limit: BODY_LIMIT_MB }));
+app.use(express.urlencoded({ extended: true, limit: BODY_LIMIT_MB }));
 
 // File upload configuration
 const storage = multer.diskStorage({


### PR DESCRIPTION
## Summary
- Read server port and body size limits from environment variables
- Allow frontend to pick server URL via `VITE_SERVER_URL`
- Remove stale DB connection flag and rely on shared status object

## Testing
- `npm run build`
- `PORT=4000 BODY_LIMIT_MB=10mb node server.js`

------
https://chatgpt.com/codex/tasks/task_e_689382bc9ed48332822a24ae61a75f6c