### PR TITLE
feat: verify sql connection in real time

### DIFF
--- a/components/SqlConnectionPanel.tsx
+++ b/components/SqlConnectionPanel.tsx
@@ -26,6 +26,8 @@ export const SqlConnectionPanel: React.FC = () => {
 
     useEffect(() => {
         checkStatus();
+        const interval = setInterval(checkStatus, 5000);
+        return () => clearInterval(interval);
     }, []);
 
     const handleConnect = async () => {
@@ -48,15 +50,13 @@ export const SqlConnectionPanel: React.FC = () => {
             const data = await res.json();
             if (data.success) {
                 setMessage('Conexión exitosa');
-                setConnected(true);
             } else {
                 setMessage(data.error || 'Error al conectar');
-                setConnected(false);
             }
         } catch (error) {
             setMessage(error instanceof Error ? error.message : String(error));
-            setConnected(false);
         }
+        await checkStatus();
         setLoading(false);
     };
 

--- a/server.js
+++ b/server.js
@@ -149,8 +149,19 @@ app.post('/api/sql/connect', async (req, res) => {
     }
 });
 
-app.get('/api/sql/status', (req, res) => {
-    res.json({ connected: !!sqlPool });
+app.get('/api/sql/status', async (req, res) => {
+    if (!sqlPool) {
+        return res.json({ connected: false });
+    }
+    try {
+        // Verify connection with a lightweight query
+        await sqlPool.request().query('SELECT 1');
+        res.json({ connected: true });
+    } catch (error) {
+        // If the query fails, consider the pool disconnected
+        sqlPool = null;
+        res.json({ connected: false, error: error.message });
+    }
 });
 
 app.get('/api/sql/permissions', async (req, res) => {


### PR DESCRIPTION
## Summary
- ensure SQL status endpoint runs a test query to confirm the connection
- poll the SQL status from the control panel to display real-time state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689397a73ab48332949b6cec49e3baaa