### PR TITLE
feat(sql): add table management endpoints and UI

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,6 +34,140 @@ const db = new Database(dbPath);
 
 let sqlPool = null;
 
+// --- SQL Server Table Definitions ---
+// Mapping of table names to their CREATE TABLE statements. These will be used
+// to ensure that the required schema exists when importing data from Excel or
+// other sources. The order of the keys in TABLE_CREATION_ORDER matters for
+// foreign-key relationships (parents first, children afterwards).
+const SQL_TABLE_DEFINITIONS = {
+    clientes: `
+        CREATE TABLE clientes (
+            id_cliente INT IDENTITY(1,1) PRIMARY KEY,
+            nombre_cuenta VARCHAR(255) UNIQUE NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    `,
+    archivos_reporte: `
+        CREATE TABLE archivos_reporte (
+            id_reporte INT IDENTITY(1,1) PRIMARY KEY,
+            id_cliente INT NOT NULL,
+            nombre_archivo VARCHAR(255),
+            hash_archivo CHAR(64) UNIQUE NOT NULL,
+            uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (id_cliente) REFERENCES clientes(id_cliente)
+        )
+    `,
+    metricas: `
+        CREATE TABLE metricas (
+            id_metricas BIGINT IDENTITY(1,1) PRIMARY KEY,
+            id_reporte INT NOT NULL,
+            [nombre_de_la_campaña] VARCHAR(255),
+            [nombre_del_conjunto_de_anuncios] VARCHAR(255),
+            [nombre_del_anuncio] VARCHAR(255),
+            [dia] DATE,
+            [imagen_video_y_presentación] VARCHAR(255),
+            [col_6] VARCHAR(255),
+            [importe_gastado_EUR] DECIMAL(12,2),
+            [entrega_de_la_campaña] VARCHAR(50),
+            [entrega_del_conjunto_de_anuncios] VARCHAR(50),
+            [entrega_del_anuncio] VARCHAR(50),
+            [impresiones] BIGINT,
+            [alcance] BIGINT,
+            [frecuencia] DECIMAL(5,2),
+            [compras] INT,
+            [visitas_a_la_página_de_destino] INT,
+            [clics_todos] INT,
+            [cpm_costo_por_mil_impresiones] DECIMAL(12,2),
+            [ctr_todos] DECIMAL(5,2),
+            [cpc_todos] DECIMAL(12,2),
+            [reproducciones_3s] BIGINT,
+            [pagos_iniciados] INT,
+            [pct_compras_por_visitas_lp] DECIMAL(5,2),
+            [me_gusta_en_facebook] INT,
+            [artículos_agregados_al_carrito] INT,
+            [pagos_iniciados_web] INT,
+            [presupuesto_de_la_campaña] DECIMAL(12,2),
+            [tipo_de_presupuesto_de_la_campaña] VARCHAR(50),
+            [públicos_personalizados_incluidos] TEXT,
+            [públicos_personalizados_excluidos] TEXT,
+            [clics_en_el_enlace] INT,
+            [información_de_pago_agregada] INT,
+            [interacción_con_la_página] INT,
+            [comentarios_de_publicaciones] INT,
+            [interacciones_con_la_publicación] INT,
+            [reacciones_a_publicaciones] INT,
+            [veces_compartidas_publicaciones] INT,
+            [puja] DECIMAL(12,2),
+            [tipo_de_puja] VARCHAR(50),
+            [url_del_sitio_web] TEXT,
+            [ctr_link_click_pct] DECIMAL(5,2),
+            [divisa] VARCHAR(10),
+            [valor_de_conversión_compras] DECIMAL(12,2),
+            [objetivo] VARCHAR(100),
+            [tipo_de_compra] VARCHAR(50),
+            [inicio_del_informe] DATE,
+            [fin_del_informe] DATE,
+            [atencion] INT,
+            [deseo] INT,
+            [interes] INT,
+            [rep_video_25_pct] BIGINT,
+            [rep_video_50_pct] BIGINT,
+            [rep_video_100_pct] BIGINT,
+            [pct_rep_3s_por_impresiones] DECIMAL(5,2),
+            [aov] DECIMAL(12,2),
+            [lp_view_rate] DECIMAL(5,2),
+            [adc_lpv] DECIMAL(12,2),
+            [captura_de_video] INT,
+            [tasa_conv_landing] DECIMAL(5,2),
+            [pct_compras] DECIMAL(5,2),
+            [visualizaciones] INT,
+            [nombre_de_la_imagen] VARCHAR(255),
+            [cvr_link_click] DECIMAL(5,2),
+            [retencion_video_short] DECIMAL(5,2),
+            [retención_de_video] DECIMAL(5,2),
+            [rep_video_75_pct] BIGINT,
+            [rep_video_95_pct] BIGINT,
+            [tiempo_promedio_video] DECIMAL(6,2),
+            [thruplays] INT,
+            [rep_video] INT,
+            [rep_video_2s_unicas] INT,
+            [ctr_unico_enlace_pct] DECIMAL(5,2),
+            [nombre_de_la_cuenta] VARCHAR(255),
+            [impresiones_compras] INT,
+            [captura_video_final] INT,
+            inserted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (id_reporte) REFERENCES archivos_reporte(id_reporte)
+        )
+    `,
+    archivos_url: `
+        CREATE TABLE archivos_url (
+            id_url INT IDENTITY(1,1) PRIMARY KEY,
+            id_cliente INT NOT NULL,
+            nombre_archivo VARCHAR(255),
+            hash_archivo CHAR(64) UNIQUE NOT NULL,
+            uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (id_cliente) REFERENCES clientes(id_cliente)
+        )
+    `,
+    vistas_preview: `
+        CREATE TABLE vistas_preview (
+            id_cliente INT NOT NULL,
+            [Account name] VARCHAR(255),
+            [Ad name] VARCHAR(255),
+            [Reach] BIGINT,
+            [Ad Preview Link] TEXT,
+            [Ad Creative Thumbnail Url] TEXT,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id_cliente, [Ad name]),
+            FOREIGN KEY (id_cliente) REFERENCES clientes(id_cliente)
+        )
+    `
+};
+
+// Order in which tables must be created and dropped
+const TABLE_CREATION_ORDER = ['clientes', 'archivos_reporte', 'metricas', 'archivos_url', 'vistas_preview'];
+const TABLE_DELETION_ORDER = ['metricas', 'archivos_url', 'vistas_preview', 'archivos_reporte', 'clientes'];
+
 // Middleware
 app.use(cors());
 app.use(express.json({ limit: BODY_LIMIT_MB }));
@@ -227,6 +361,67 @@ app.get('/api/sql/permissions', async (req, res) => {
     } catch (error) {
         console.error('[SQL] Error al verificar permisos:', error.message);
         res.status(500).json({ error: error.message });
+    }
+});
+
+// --- Manage SQL Server tables ---
+// Creates all tables defined in SQL_TABLE_DEFINITIONS if they don't exist.
+app.post('/api/sql/init-tables', async (req, res) => {
+    if (!sqlPool) {
+        return res.status(400).json({ error: 'Not connected' });
+    }
+    const created = [];
+    try {
+        for (const table of TABLE_CREATION_ORDER) {
+            // Check if table exists
+            const exists = await sqlPool
+                .request()
+                .query(`SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='${table}'`);
+            if (exists.recordset.length === 0) {
+                await sqlPool.request().query(SQL_TABLE_DEFINITIONS[table]);
+                created.push(table);
+            }
+        }
+        res.json({ success: true, created });
+    } catch (error) {
+        console.error('[SQL] Error creating tables:', error.message);
+        res.status(500).json({ success: false, error: error.message });
+    }
+});
+
+// Drops all known tables (children first to respect FKs)
+app.delete('/api/sql/tables', async (req, res) => {
+    if (!sqlPool) {
+        return res.status(400).json({ error: 'Not connected' });
+    }
+    try {
+        for (const table of TABLE_DELETION_ORDER) {
+            await sqlPool
+                .request()
+                .query(`IF OBJECT_ID('${table}', 'U') IS NOT NULL DROP TABLE ${table};`);
+        }
+        res.json({ success: true });
+    } catch (error) {
+        console.error('[SQL] Error dropping tables:', error.message);
+        res.status(500).json({ success: false, error: error.message });
+    }
+});
+
+// Deletes all data from tables without removing structure
+app.delete('/api/sql/tables/data', async (req, res) => {
+    if (!sqlPool) {
+        return res.status(400).json({ error: 'Not connected' });
+    }
+    try {
+        for (const table of TABLE_DELETION_ORDER) {
+            await sqlPool
+                .request()
+                .query(`IF OBJECT_ID('${table}', 'U') IS NOT NULL DELETE FROM ${table};`);
+        }
+        res.json({ success: true });
+    } catch (error) {
+        console.error('[SQL] Error clearing table data:', error.message);
+        res.status(500).json({ success: false, error: error.message });
     }
 });
 


### PR DESCRIPTION
## Summary
- add SQL Server table definitions and ordered lists
- expose endpoints to create, drop and clear SQL tables
- add control panel actions to trigger table management from UI

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68949ecde67c8332ad1af41a65ebf95a