### PR TITLE
Add SQL Excel import endpoint

### DIFF
--- a/database.ts
+++ b/database.ts
@@ -667,7 +667,20 @@ const db = {
     },
 
     async getImportHistory(): Promise<ImportBatch[]> {
-        return await this.select('import_history', []);
+        const history = await this.select('import_history', []);
+        if (Array.isArray(history)) {
+            return history;
+        }
+        if (history && typeof history === 'object') {
+            if (Array.isArray((history as any).default)) {
+                return (history as any).default as ImportBatch[];
+            }
+            const values = Object.values(history as any);
+            if (values.length === 1 && Array.isArray(values[0])) {
+                return values[0] as ImportBatch[];
+            }
+        }
+        return [];
     },
 
     async saveImportHistory(history: ImportBatch[]): Promise<void> {


### PR DESCRIPTION
## Summary
- add `/api/sql/import-excel` to upload Meta Excel files and persist data in SQL Server, generating clients and reports dynamically
- parse table definition to map Excel columns and store metric rows
- normalize server-stored import history to always return an array

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894b2f6ea788332b1cbc94dfab712c9