### PR TITLE
Centralize shared utilities

### DIFF
--- a/database.ts
+++ b/database.ts
@@ -3,6 +3,7 @@ import { indexedDBManager } from './lib/indexedDBManager';
 import { localServerClient } from './lib/localServerClient';
 import { notify } from './components/notificationService';
 import Logger from './Logger';
+import { CRITICAL_TABLES } from './database/constants';
 
 /**
  * Pure IndexedDB Database Manager - Ver6 Sistema Híbrido
@@ -97,8 +98,7 @@ const db = {
         Logger.info(`[DB] Executing: SELECT * FROM ${table}`);
         
         // Critical authentication data from localStorage ONLY
-        const criticalTables = ['users', 'logged_in_user', 'config'];
-        if (criticalTables.includes(table)) {
+        if (CRITICAL_TABLES.includes(table)) {
             try {
                 const localData = localStorage.getItem(`db_${table}`);
                 if (localData) {
@@ -187,8 +187,7 @@ const db = {
         Logger.info(`[DB] Data size: ${JSON.stringify(data).length} characters`);
 
         // Critical authentication data stays in localStorage for immediate access
-        const criticalTables = ['users', 'logged_in_user', 'config'];
-        if (criticalTables.includes(table)) {
+        if (CRITICAL_TABLES.includes(table)) {
             try {
                 const dataString = JSON.stringify(data);
                 localStorage.setItem(`db_${table}`, dataString);

--- a/database/constants.ts
+++ b/database/constants.ts
@@ -1,0 +1,2 @@
+export const CRITICAL_TABLES = ['users', 'logged_in_user', 'config'] as const;
+export type CriticalTable = typeof CRITICAL_TABLES[number];

--- a/database_pure.ts
+++ b/database_pure.ts
@@ -1,6 +1,7 @@
 import { Client, User, PerformanceRecord, AllLookerData, BitacoraReport, UploadedVideo, ImportBatch, MetaApiConfig, ProcessedHashes } from './types';
 import { indexedDBManager } from './lib/indexedDBManager';
 import { notify } from './components/notificationService';
+import { CRITICAL_TABLES } from './database/constants';
 
 /**
  * Pure IndexedDB Database Manager - Ver6 Sistema 100% IndexedDB
@@ -67,8 +68,7 @@ const db = {
         console.log(`[DB] Executing: SELECT * FROM ${table}`);
         
         // Critical authentication data from localStorage ONLY
-        const criticalTables = ['users', 'logged_in_user', 'config'];
-        if (criticalTables.includes(table)) {
+        if (CRITICAL_TABLES.includes(table)) {
             try {
                 const localData = localStorage.getItem(`db_${table}`);
                 if (localData) {
@@ -109,8 +109,7 @@ const db = {
         console.log(`[DB] Data size: ${JSON.stringify(data).length} characters`);
 
         // Critical authentication data stays in localStorage for immediate access
-        const criticalTables = ['users', 'logged_in_user', 'config'];
-        if (criticalTables.includes(table)) {
+        if (CRITICAL_TABLES.includes(table)) {
             try {
                 const dataString = JSON.stringify(data);
                 localStorage.setItem(`db_${table}`, dataString);

--- a/lib/dataProcessor.ts
+++ b/lib/dataProcessor.ts
@@ -1,5 +1,6 @@
 import { read, utils, WorkBook, WorkSheet } from 'xlsx';
 import { Client, PerformanceRecord, AllLookerData, ClientLookerData } from '../types';
+import { parseDateForSort } from './parseDateForSort';
 
 // --- UTILITY FUNCTIONS ---
 const normalizeHeader = (header: string): string => {
@@ -15,17 +16,6 @@ const parseNumber = (value: any): number => {
         return isNaN(num) ? 0 : num;
     }
     return 0;
-};
-
-const parseDateForSort = (dateStr: string): Date | null => {
-    if (!dateStr || typeof dateStr !== 'string') return null;
-    const parts = dateStr.split('/');
-    if (parts.length === 3) {
-        // Assuming DD/MM/YYYY
-        return new Date(`${parts[2]}-${parts[1]}-${parts[0]}`);
-    }
-    const date = new Date(dateStr);
-    return isNaN(date.getTime()) ? null : date;
 };
 
 // --- COLUMN MAPPING ---

--- a/lib/parseDateForSort.ts
+++ b/lib/parseDateForSort.ts
@@ -1,4 +1,4 @@
-export function parseDateForSort(value) {
+export function parseDateForSort(value: unknown): Date | null {
     if (value === null || value === undefined) return null;
     if (typeof value === 'number') {
         // Excel serial number (days since 1899-12-30)

--- a/parseDateForSort.test.ts
+++ b/parseDateForSort.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseDateForSort } from './lib/parseDateForSort.js';
+import { parseDateForSort } from './lib/parseDateForSort';
 
 describe('parseDateForSort', () => {
   it('parses DD/MM/YYYY strings', () => {

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ import xlsx from 'xlsx';
 import crypto from 'crypto';
 import logger from './serverLogger.js';
 import { SQL_TABLE_DEFINITIONS, getCreationOrder, getDeletionOrder } from './sqlTables.js';
-import { parseDateForSort } from './lib/parseDateForSort.js';
+import { parseDateForSort } from './lib/parseDateForSort.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## Summary
- centralize critical table names in shared database/constants module
- consolidate parseDateForSort into single TypeScript utility and update imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960b0b3c348332a7ab9f58bee9a1e5