### PR TITLE
Compile parseDate utility for server use

### DIFF
--- a/lib/dataProcessor.ts
+++ b/lib/dataProcessor.ts
@@ -1,6 +1,6 @@
 import { read, utils, WorkBook, WorkSheet } from 'xlsx';
 import { Client, PerformanceRecord, AllLookerData, ClientLookerData } from '../types';
-import { parseDateForSort } from './parseDateForSort';
+import { parseDateForSort } from './parseDateForSort.ts';
 
 // --- UTILITY FUNCTIONS ---
 const normalizeHeader = (header: string): string => {

--- a/lib/parseDateForSort.js
+++ b/lib/parseDateForSort.js
@@ -1,0 +1,22 @@
+export function parseDateForSort(value) {
+    if (value === null || value === undefined)
+        return null;
+    if (typeof value === 'number') {
+        // Excel serial number (days since 1899-12-30)
+        const date = new Date(Math.round((value - 25569) * 86400 * 1000));
+        return isNaN(date.getTime()) ? null : date;
+    }
+    if (value instanceof Date) {
+        return isNaN(value.getTime()) ? null : value;
+    }
+    if (typeof value === 'string') {
+        const parts = value.split('/');
+        if (parts.length === 3) {
+            const d = new Date(`${parts[2]}-${parts[1]}-${parts[0]}`);
+            return isNaN(d.getTime()) ? null : d;
+        }
+        const d = new Date(value);
+        return isNaN(d.getTime()) ? null : d;
+    }
+    return null;
+}

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc lib/parseDateForSort.ts --outDir lib --noEmit false --module esnext --target ES2022 --moduleResolution node && vite build",
     "preview": "vite preview",
     "server": "node server.js",
     "start": "node ./scripts/free-ports.cjs && concurrently \"npm run server\" \"npm run dev\"",
     "dev:full": "concurrently \"npm run server\" \"npm run dev\"",
-        "test": "vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "@google/genai": "^1.11.0",

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ import xlsx from 'xlsx';
 import crypto from 'crypto';
 import logger from './serverLogger.js';
 import { SQL_TABLE_DEFINITIONS, getCreationOrder, getDeletionOrder } from './sqlTables.js';
-import { parseDateForSort } from './lib/parseDateForSort.ts';
+import { parseDateForSort } from './lib/parseDateForSort.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## Summary
- Transpile `lib/parseDateForSort.ts` to JavaScript during build so the server can import it
- Adjust server and library imports to use the generated file and resolve TypeScript explicitly
- Include compiled `parseDateForSort.js` in repository

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689613ef6d6483329831b67da16ec1f1