### PR TITLE
feat: meta import db flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Este repositorio contiene todo lo necesario para ejecutar la app localmente.
 3. Inicia el sistema:
    `npm run start` (esto ejecuta frontend y backend juntos)
 
+### Pruebas de importación de Meta
+
+Para verificar el nuevo flujo de importación de reportes de Meta:
+
+1. Prepara un archivo XLSX con columnas `account_name`, `date` y `ad_id` más métricas.
+2. Caso 1: si el `account_name` no existe, al importar se crea un nuevo cliente y se insertan las métricas.
+3. Caso 2: si el cliente ya existe, se actualizan o insertan métricas sin duplicados gracias al índice `(client_id,date,ad_id)`.
+4. Reimportar el mismo archivo no debe generar filas duplicadas; el log mostrará conteos de filas insertadas y actualizadas.
+
 ## Número de compilación
 
 El número de compilación del sistema se mantiene en [`build-info.ts`](build-info.ts).

--- a/database/MetaDb.ts
+++ b/database/MetaDb.ts
@@ -1,0 +1,133 @@
+import { Client } from '../types.js';
+import normalizeName from '../lib/normalizeName.js';
+
+export interface MetaMetricRow {
+  clientId: number;
+  date: string;
+  adId: string;
+  [key: string]: any;
+}
+
+export interface MetaDb {
+  getClientByNameNorm(nameNorm: string): Promise<Client | undefined>;
+  upsertClient(client: Client): Promise<number>;
+  upsertMetaMetrics(rows: MetaMetricRow[]): Promise<{ inserted: number; updated: number }>;
+}
+
+export function createMetaDb(): MetaDb {
+  if (process.env.SQLSERVER_HOST) {
+    return new MetaDbSql();
+  }
+  return new MetaDbLocal();
+}
+
+class MetaDbLocal implements MetaDb {
+  private clients: Map<string, Client> = new Map();
+  private metrics: Map<string, any> = new Map();
+
+  async getClientByNameNorm(nameNorm: string): Promise<Client | undefined> {
+    for (const c of this.clients.values()) {
+      if (c.nameNorm === nameNorm) return c;
+    }
+    return undefined;
+  }
+
+  async upsertClient(client: Client): Promise<number> {
+    const nameNorm = client.nameNorm || normalizeName(client.name);
+    let existing = await this.getClientByNameNorm(nameNorm);
+    if (existing) {
+      const merged = { ...existing, ...client, nameNorm };
+      this.clients.set(existing.id, merged);
+      return Number(existing.id);
+    }
+    const id = String(this.clients.size + 1);
+    const newClient: Client = { ...client, id, nameNorm };
+    this.clients.set(id, newClient);
+    return Number(id);
+  }
+
+  async upsertMetaMetrics(rows: MetaMetricRow[]): Promise<{ inserted: number; updated: number }> {
+    let inserted = 0;
+    let updated = 0;
+    for (const row of rows) {
+      const key = `${row.clientId}-${row.date}-${row.adId}`;
+      if (this.metrics.has(key)) {
+        const existing = this.metrics.get(key);
+        this.metrics.set(key, { ...existing, ...row });
+        updated++;
+      } else {
+        this.metrics.set(key, row);
+        inserted++;
+      }
+    }
+    return { inserted, updated };
+  }
+}
+
+import sql from 'mssql';
+
+class MetaDbSql implements MetaDb {
+  private pool: Promise<sql.ConnectionPool>;
+  constructor() {
+    const cfg: sql.config = {
+      server: process.env.SQLSERVER_HOST || 'localhost',
+      database: process.env.SQLSERVER_DB || 'master',
+      user: process.env.SQLSERVER_USER,
+      password: process.env.SQLSERVER_PASS,
+      options: { trustServerCertificate: true },
+    };
+    this.pool = sql.connect(cfg);
+  }
+
+  private async ensurePool() {
+    return this.pool;
+  }
+
+  async getClientByNameNorm(nameNorm: string): Promise<Client | undefined> {
+    const pool = await this.ensurePool();
+    const result = await pool
+      .request()
+      .input('nameNorm', sql.NVarChar, nameNorm)
+      .query('SELECT TOP 1 id, name, name_norm FROM clients WHERE name_norm = @nameNorm');
+    const row = result.recordset[0];
+    return row ? { id: String(row.id), name: row.name, nameNorm: row.name_norm, logo: '', currency: '', userId: '' } : undefined;
+  }
+
+  async upsertClient(client: Client): Promise<number> {
+    const pool = await this.ensurePool();
+    const nameNorm = client.nameNorm || normalizeName(client.name);
+    const result = await pool
+      .request()
+      .input('name', sql.NVarChar, client.name)
+      .input('nameNorm', sql.NVarChar, nameNorm)
+      .query(`MERGE clients AS target
+ON target.name_norm = @nameNorm
+WHEN MATCHED THEN UPDATE SET name = @name
+WHEN NOT MATCHED THEN INSERT (name, name_norm) VALUES (@name, @nameNorm)
+OUTPUT inserted.id;`);
+    const id = result.recordset[0]?.id;
+    return Number(id);
+  }
+
+  async upsertMetaMetrics(rows: MetaMetricRow[]): Promise<{ inserted: number; updated: number }> {
+    const pool = await this.ensurePool();
+    let inserted = 0;
+    let updated = 0;
+    for (const row of rows) {
+      const request = pool
+        .request()
+        .input('clientId', sql.Int, row.clientId)
+        .input('date', sql.Date, row.date)
+        .input('adId', sql.NVarChar, row.adId)
+        .input('spend', sql.Decimal(18, 2), row.spend ?? null);
+      const result = await request.query(`MERGE facts_meta AS target
+USING (SELECT @clientId AS client_id, @date AS [date], @adId AS ad_id, @spend AS spend) AS source
+ON (target.client_id = source.client_id AND target.[date] = source.[date] AND target.ad_id = source.ad_id)
+WHEN MATCHED THEN UPDATE SET spend = source.spend
+WHEN NOT MATCHED THEN INSERT (client_id, [date], ad_id, spend) VALUES (source.client_id, source.[date], source.ad_id, source.spend);
+`);
+      if (result.rowsAffected && result.rowsAffected[0] === 1) inserted++; else updated++;
+    }
+    return { inserted, updated };
+  }
+}

--- a/importers/importMetaReport.ts
+++ b/importers/importMetaReport.ts
@@ -1,0 +1,53 @@
+import { read, utils } from 'xlsx';
+import { MetaDb, MetaMetricRow } from '../database/MetaDb.js';
+import normalizeName from '../lib/normalizeName.js';
+import Logger from '../Logger.js';
+
+/**
+ * Import Meta report from an ArrayBuffer/Buffer. Parses Excel, creates/uses client, and upserts metrics.
+ */
+export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
+  const workbook = read(data, { type: 'array' });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows = utils.sheet_to_json<any>(sheet);
+
+  if (rows.length === 0) {
+    Logger.warn('[importMetaReport] No rows in file');
+    return { processed: 0, inserted: 0, updated: 0, discarded: 0 };
+  }
+
+  const first = rows[0];
+  const rawName = first['account_name'] || first['Account name'] || first['nombre de la cuenta'] || '';
+  const nameNorm = normalizeName(String(rawName));
+  let client = await db.getClientByNameNorm(nameNorm);
+  if (!client) {
+    client = { id: '', name: String(rawName), nameNorm, logo: '', currency: '', userId: '' };
+    const id = await db.upsertClient(client);
+    client.id = String(id);
+    Logger.info(`[importMetaReport] Created client ${client.name} (${id})`);
+  }
+
+  const metricRows: MetaMetricRow[] = [];
+  let discarded = 0;
+  for (const r of rows) {
+    const date = r['date'] || r['day'] || r['día'];
+    const adId = r['ad_id'] || r['Ad ID'] || r['ad id'];
+    if (!date || !adId) {
+      discarded++;
+      continue;
+    }
+    const row: MetaMetricRow = {
+      clientId: Number(client.id),
+      date: new Date(date).toISOString().slice(0, 10),
+      adId: String(adId),
+      spend: r['spend'] || r['amount_spent (eur)'] || r['importe gastado (eur)'],
+    };
+    if (r['days_detected'] === undefined) row['days_detected'] = 0;
+    metricRows.push(row);
+  }
+
+  const result = await db.upsertMetaMetrics(metricRows);
+  Logger.info(`[importMetaReport] processed=${metricRows.length} inserted=${result.inserted} updated=${result.updated} discarded=${discarded}`);
+  return { processed: metricRows.length, inserted: result.inserted, updated: result.updated, discarded };
+}
+export default importMetaReport;

--- a/lib/normalizeName.ts
+++ b/lib/normalizeName.ts
@@ -1,0 +1,11 @@
+export function normalizeName(raw: string): string {
+  if (!raw) return '';
+  const collapsed = raw
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ');
+  return collapsed;
+}
+export default normalizeName;

--- a/scripts/meta-schema.sql
+++ b/scripts/meta-schema.sql
@@ -1,0 +1,25 @@
+-- Idempotent creation of clients and facts_meta tables
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'clients') AND type in (N'U'))
+BEGIN
+    CREATE TABLE clients (
+        id INT IDENTITY(1,1) PRIMARY KEY,
+        name NVARCHAR(255) NOT NULL,
+        name_norm NVARCHAR(255) NOT NULL UNIQUE,
+        created_at DATETIME DEFAULT GETDATE()
+    );
+END;
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'facts_meta') AND type in (N'U'))
+BEGIN
+    CREATE TABLE facts_meta (
+        client_id INT NOT NULL,
+        [date] DATE NOT NULL,
+        ad_id NVARCHAR(255) NOT NULL,
+        spend DECIMAL(18,2) NULL,
+        days_detected INT DEFAULT 0,
+        PRIMARY KEY (client_id, [date], ad_id)
+    );
+    CREATE UNIQUE INDEX UX_facts_meta_client_date_ad ON facts_meta (client_id, [date], ad_id);
+END;
+GO

--- a/sqlTables.js
+++ b/sqlTables.js
@@ -1,4 +1,28 @@
 export const TABLES = {
+  clients: {
+    create: `
+        CREATE TABLE clients (
+            id INT IDENTITY(1,1) PRIMARY KEY,
+            name NVARCHAR(255) NOT NULL,
+            name_norm NVARCHAR(255) NOT NULL UNIQUE,
+            created_at DATETIME DEFAULT GETDATE()
+        )
+    `,
+    dependencies: []
+  },
+  facts_meta: {
+    create: `
+        CREATE TABLE facts_meta (
+            client_id INT NOT NULL,
+            [date] DATE NOT NULL,
+            ad_id NVARCHAR(255) NOT NULL,
+            spend DECIMAL(18,2),
+            days_detected INT DEFAULT 0,
+            PRIMARY KEY (client_id, [date], ad_id)
+        )
+    `,
+    dependencies: ['clients']
+  },
   clientes: {
     create: `
         CREATE TABLE clientes (

--- a/types.ts
+++ b/types.ts
@@ -116,6 +116,8 @@ export interface User {
 export interface Client {
   id: string;
   name: string;
+  /** Normalized name for uniqueness checks */
+  nameNorm?: string;
   logo: string;
   currency: string;
   userId: string;


### PR DESCRIPTION
## Summary
- add normalizeName utility and extend Client with normalized field
- introduce MetaDb abstraction with local and SQL Server implementations
- add Meta report importer orchestrating client creation and metric upserts
- provide SQL schema for clients and facts_meta tables
- document Meta import testing steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68961b3d89108332a6f16564687b118f