### PR TITLE
feat: add runtime data source switching

### DIFF
--- a/components/ClientManager.tsx
+++ b/components/ClientManager.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useMemo } from 'react';
 import { Client, User } from '../types';
 import { ClientFormModal } from './ClientFormModal';
+import { DataSourceSwitch } from './DataSourceSwitch';
 
 interface ClientManagerProps {
     clients: Client[];
@@ -75,12 +76,15 @@ export const ClientManager: React.FC<ClientManagerProps> = ({ clients, setClient
                     <h3 className="text-xl font-bold text-brand-text">
                         {isAdmin ? 'Todos los Clientes' : 'Mis Clientes'} ({visibleClients.length})
                     </h3>
-                    <button onClick={handleOpenAddModal} className="bg-brand-primary hover:bg-brand-primary-hover text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors flex items-center gap-2">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                           <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
-                        </svg>
-                        Añadir Cliente
-                    </button>
+                    <div className="flex items-center gap-4">
+                        <DataSourceSwitch />
+                        <button onClick={handleOpenAddModal} className="bg-brand-primary hover:bg-brand-primary-hover text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors flex items-center gap-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                               <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+                            </svg>
+                            Añadir Cliente
+                        </button>
+                    </div>
                 </div>
                 
                 {visibleClients.length > 0 ? (

--- a/components/DataSourceSwitch.tsx
+++ b/components/DataSourceSwitch.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { DataSource } from '../constants';
+import { useDataSource } from '../context/DataSourceContext';
+
+export const DataSourceSwitch: React.FC = () => {
+  const { dataSource, setDataSource } = useDataSource();
+  return (
+    <div className="flex rounded-lg bg-brand-border p-1">
+      <button
+        onClick={() => setDataSource(DataSource.LOCAL)}
+        className={`px-3 py-1 text-sm font-semibold rounded-md transition-colors ${dataSource === DataSource.LOCAL ? 'bg-brand-primary text-white' : 'text-brand-text-secondary hover:bg-brand-surface'}`}
+      >
+        Local
+      </button>
+      <button
+        onClick={() => setDataSource(DataSource.SQL)}
+        className={`px-3 py-1 text-sm font-semibold rounded-md transition-colors ${dataSource === DataSource.SQL ? 'bg-brand-primary text-white' : 'text-brand-text-secondary hover:bg-brand-surface'}`}
+      >
+        SQL Express
+      </button>
+    </div>
+  );
+};

--- a/components/ImportView.tsx
+++ b/components/ImportView.tsx
@@ -27,6 +27,8 @@ interface ImportViewProps {
     onSyncFromMeta: (clientId: string) => Promise<void>;
     metaApiConfig: MetaApiConfig | null;
     currentUser: User;
+    refreshClients: () => Promise<void>;
+    refreshPerformance: () => Promise<void>;
 }
 
 type Feedback = { type: 'info' | 'success' | 'error', message: string };
@@ -60,7 +62,7 @@ const ImportCard: React.FC<{
 export const ImportView: React.FC<ImportViewProps> = ({
     clients, setClients, lookerData, setLookerData,
     performanceData, setPerformanceData, bitacoraReports, setBitacoraReports,
-    onSyncFromMeta, metaApiConfig, currentUser
+    onSyncFromMeta, metaApiConfig, currentUser, refreshClients, refreshPerformance
 }) => {
 
     // Validación defensiva para props
@@ -150,6 +152,8 @@ export const ImportView: React.FC<ImportViewProps> = ({
             addLog('Importación completada correctamente');
             setFeedback({ type: 'success', message: `Importación a SQL exitosa: ${result.message || 'OK'}` });
             await loadSqlHistory();
+            await refreshClients();
+            await refreshPerformance();
         } catch (error) {
             const message = error instanceof Error ? error.message : 'Error inesperado.';
             addLog(`Error: ${message}`);
@@ -273,6 +277,9 @@ export const ImportView: React.FC<ImportViewProps> = ({
             }
         }
         await db.saveProcessedHashes(newHashes);
+
+        await refreshClients();
+        await refreshPerformance();
     };
 
     const processAndSaveLookerData = async (file: File, clientList: Client[]) => {
@@ -320,6 +327,9 @@ export const ImportView: React.FC<ImportViewProps> = ({
             }
         }
         await db.saveProcessedHashes(newHashes);
+
+        await refreshClients();
+        await refreshPerformance();
     };
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>, source: 'looker' | 'meta' | 'txt') => {

--- a/components/PerformanceView.tsx
+++ b/components/PerformanceView.tsx
@@ -10,6 +10,7 @@ import { VideoUploadModal } from './VideoUploadModal';
 import db from '../database';
 import Logger from '../Logger';
 import { MetricsDetailModal } from './MetricsDetailModal';
+import { DataSourceSwitch } from './DataSourceSwitch';
 
 type FilterMode = 'all' | 'image' | 'video';
 type DisplayMode = 'table' | 'cards';
@@ -114,6 +115,12 @@ export const PerformanceView: React.FC<PerformanceViewProps> = ({ clients, getPe
     const [filterMode, setFilterMode] = useState<FilterMode>('all');
     const [displayMode, setDisplayMode] = useState<DisplayMode>('cards');
     const [selectedClient, setSelectedClient] = useState<Client | null>(null);
+
+    useEffect(() => {
+        if (selectedClient && !safeClients.some(c => c.id === selectedClient.id)) {
+            setSelectedClient(null);
+        }
+    }, [safeClients, selectedClient]);
     const [bulkAnalysisState, setBulkAnalysisState] = useState({ active: false, current: 0, total: 0 });
     const [accountAverages, setAccountAverages] = useState<AccountAverages | null>(null);
 
@@ -513,7 +520,10 @@ export const PerformanceView: React.FC<PerformanceViewProps> = ({ clients, getPe
                             <h2 className="text-2xl font-bold text-brand-text">Rendimiento por Cliente</h2>
                             <p className="text-brand-text-secondary mt-1">Gestiona el rendimiento de las campañas publicitarias.</p>
                         </div>
-                        <DateRangePicker onDateChange={onDateChange} startDate={startDate} endDate={endDate} />
+                        <div className="flex items-center gap-4">
+                            <DataSourceSwitch />
+                            <DateRangePicker onDateChange={onDateChange} startDate={startDate} endDate={endDate} />
+                        </div>
                     </header>
 
                     <div className="bg-blue-900/20 border border-blue-500 rounded-lg p-8 text-center">
@@ -541,7 +551,10 @@ export const PerformanceView: React.FC<PerformanceViewProps> = ({ clients, getPe
                         <h2 className="text-2xl font-bold text-brand-text">Rendimiento por Cliente</h2>
                         <p className="text-brand-text-secondary mt-1">Selecciona un cliente para ver el detalle de sus anuncios.</p>
                     </div>
-                    <DateRangePicker onDateChange={onDateChange} startDate={startDate} endDate={endDate} />
+                    <div className="flex items-center gap-4">
+                        <DataSourceSwitch />
+                        <DateRangePicker onDateChange={onDateChange} startDate={startDate} endDate={endDate} />
+                    </div>
                 </header>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -576,7 +589,7 @@ export const PerformanceView: React.FC<PerformanceViewProps> = ({ clients, getPe
                          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" /></svg>
                         Volver a la lista de clientes
                     </button>
-                     <div className="flex flex-col md:flex-row justify-between md:items-center gap-4">
+                    <div className="flex flex-col md:flex-row justify-between md:items-center gap-4">
                         <div className="flex items-center gap-4">
                             <img src={selectedClient.logo} alt={selectedClient.name} className="h-12 w-12 rounded-full bg-brand-border" />
                             <div>
@@ -584,7 +597,10 @@ export const PerformanceView: React.FC<PerformanceViewProps> = ({ clients, getPe
                                 <p className="text-brand-text-secondary">Datos del {new Date(startDate).toLocaleDateString('es-ES')} al {new Date(endDate).toLocaleDateString('es-ES')}</p>
                             </div>
                         </div>
-                         <DateRangePicker onDateChange={onDateChange} startDate={startDate} endDate={endDate} />
+                        <div className="flex items-center gap-4">
+                            <DataSourceSwitch />
+                            <DateRangePicker onDateChange={onDateChange} startDate={startDate} endDate={endDate} />
+                        </div>
                     </div>
                 </header>
 

--- a/constants.ts
+++ b/constants.ts
@@ -1,6 +1,9 @@
 
 import { Placement, PlacementId, FormatGroup, UiType } from './types';
 
+export enum DataSource { LOCAL = 'local', SQL = 'sql' }
+export const DATA_SOURCE_STORAGE_KEY = 'app:dataSource';
+
 export const META_ADS_GUIDELINES = `
 ### Mejoras automáticas de Meta Advantage+ para anuncios estáticos y de video
 

--- a/context/DataSourceContext.tsx
+++ b/context/DataSourceContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useState, useRef, useEffect } from 'react';
+import { DataSource, DATA_SOURCE_STORAGE_KEY } from '../constants';
+import Logger from '../Logger';
+
+interface DataSourceContextValue {
+  dataSource: DataSource;
+  setDataSource: (ds: DataSource) => void;
+}
+
+const DataSourceContext = createContext<DataSourceContextValue | undefined>(undefined);
+
+export const DataSourceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [dataSource, setDataSourceState] = useState<DataSource>(() => {
+    const stored = localStorage.getItem(DATA_SOURCE_STORAGE_KEY) as DataSource | null;
+    return stored === DataSource.SQL ? DataSource.SQL : DataSource.LOCAL;
+  });
+
+  const didInit = useRef(false);
+  useEffect(() => {
+    if (didInit.current) return;
+    didInit.current = true;
+    Logger.info(`[DS] loaded ${dataSource}`);
+  }, [dataSource]);
+
+  const setDataSource = (ds: DataSource) => {
+    setDataSourceState(ds);
+    localStorage.setItem(DATA_SOURCE_STORAGE_KEY, ds);
+    Logger.info(`[DS] switched to ${ds}`);
+  };
+
+  return (
+    <DataSourceContext.Provider value={{ dataSource, setDataSource }}>
+      {children}
+    </DataSourceContext.Provider>
+  );
+};
+
+export const useDataSource = () => {
+  const ctx = useContext(DataSourceContext);
+  if (!ctx) throw new Error('useDataSource must be used within DataSourceProvider');
+  return ctx;
+};

--- a/index.tsx
+++ b/index.tsx
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css'; // Our new CSS file
 import { NotificationProvider } from './components/NotificationProvider';
+import { DataSourceProvider } from './context/DataSourceContext';
 // import MinimalApp from './MinimalApp';
 
 const rootElement = document.getElementById('root');
@@ -16,7 +17,9 @@ const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <NotificationProvider>
-      <App />
+      <DataSourceProvider>
+        <App />
+      </DataSourceProvider>
     </NotificationProvider>
   </React.StrictMode>
 );

--- a/lib/dataRouter.ts
+++ b/lib/dataRouter.ts
@@ -1,0 +1,79 @@
+import { DataSource } from '../constants';
+import Logger from '../Logger';
+import { localServerClient } from './localServerClient';
+import { indexedDBManager } from './indexedDBManager';
+import { Client, PerformanceRecord, ImportBatch } from '../types';
+
+const fetchJson = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Request failed: ${url}`);
+  }
+  return res.json();
+};
+
+const normalizeClients = (data: any): Client[] => {
+  if (Array.isArray(data)) return data;
+  if (data && Array.isArray(data?.data)) return data.data;
+  return Object.values(data || {});
+};
+
+const flattenRows = (value: any): PerformanceRecord[] => {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap(v => Array.isArray((v as any)?.rows) ? (v as any).rows : (v as any));
+  }
+  if (Array.isArray((value as any).rows)) {
+    return (value as any).rows;
+  }
+  return [];
+};
+
+const normalizePerformance = (raw: any): Record<string, PerformanceRecord[]> => {
+  const result: Record<string, PerformanceRecord[]> = {};
+  let total = 0;
+  const data = raw?.data ?? raw;
+  if (Array.isArray(data)) {
+    const rows = flattenRows(data);
+    result['default'] = rows;
+    total += rows.length;
+  } else if (data && typeof data === 'object') {
+    for (const [key, value] of Object.entries(data)) {
+      const rows = flattenRows(value);
+      result[key] = rows;
+      total += rows.length;
+    }
+  }
+  Logger.info(`[FETCH] performance flattened rows=${total}`);
+  return result;
+};
+
+export async function getClients(ds: DataSource): Promise<Client[]> {
+  Logger.info('[FETCH]', { ds, resource: 'clients' });
+  if (ds === DataSource.LOCAL) {
+    const clients = await localServerClient.loadClients().catch(() => []);
+    return normalizeClients(clients);
+  }
+  const data = await fetchJson('/api/sql/clients');
+  return normalizeClients(data);
+}
+
+export async function getPerformance(ds: DataSource): Promise<Record<string, PerformanceRecord[]>> {
+  Logger.info('[FETCH]', { ds, resource: 'performance' });
+  if (ds === DataSource.LOCAL) {
+    const raw = await localServerClient.loadPerformanceData().catch(() => ({}));
+    return normalizePerformance(raw);
+  }
+  const data = await fetchJson('/api/sql/performance');
+  return normalizePerformance(data);
+}
+
+export async function getImportHistory(ds: DataSource): Promise<ImportBatch[]> {
+  Logger.info('[FETCH]', { ds, resource: 'import_history' });
+  if (ds === DataSource.LOCAL) {
+    return indexedDBManager.getImportHistory();
+  }
+  const data = await fetchJson('/api/sql/import-history');
+  const history = data?.history ?? data;
+  return Array.isArray(history) ? history : [];
+}


### PR DESCRIPTION
## Summary
- add global DataSource context with persistence
- implement switch UI and router for local vs SQL data
- refresh clients and performance when importing data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68962222dd748332aa853665a66ccec9