### PR TITLE
feat: import meta data with client confirmation

### DIFF
--- a/importers/importLookerReport.ts
+++ b/importers/importLookerReport.ts
@@ -23,11 +23,11 @@ export async function importLookerReport(data: ArrayBuffer, db: MetaDb): Promise
 
   const staging: LookerUrlRow[] = [];
   const unmatched: { account: string; id: string }[] = [];
-  const clientNames: Record<number, string> = {};
+  const clientNames: Record<string, string> = {};
 
   for (const r of rows) {
     const rawAccount = r['account_name'] || r['Account name'] || r['nombre de la cuenta'] || '';
-    const client = await db.getClientByNameNorm(normalizeName(String(rawAccount)));
+    const client = await db.findClientByNameNorm(normalizeName(String(rawAccount)));
     const adId = r['ad_id'] || r['Ad ID'] || r['ad id'];
     const adName = r['ad_name'] || r['Ad name'] || r['nombre del anuncio'];
     const adNameNorm = adName ? normalizeName(String(adName)) : undefined;
@@ -39,9 +39,9 @@ export async function importLookerReport(data: ArrayBuffer, db: MetaDb): Promise
       unmatched.push({ account: String(rawAccount), id: identifier });
       continue;
     }
-    clientNames[Number(client.id)] = client.name;
+    clientNames[client.id] = client.name;
     staging.push({
-      clientId: Number(client.id),
+      clientId: client.id,
       adId: adId ? String(adId) : undefined,
       adNameNorm,
       adPreviewLink: preview,

--- a/server/migrations/003_fix_sql_schema.sql
+++ b/server/migrations/003_fix_sql_schema.sql
@@ -1,0 +1,57 @@
+-- A) clients: asegurar columna client_id (o renombrar id -> client_id)
+IF COL_LENGTH('dbo.clients','client_id') IS NULL AND COL_LENGTH('dbo.clients','id') IS NOT NULL
+BEGIN
+  EXEC sp_rename 'dbo.clients.id', 'client_id', 'COLUMN';
+END;
+
+-- Si no existe clients, créala completa
+IF OBJECT_ID('dbo.clients','U') IS NULL
+BEGIN
+  CREATE TABLE dbo.clients(
+    client_id UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID(),
+    name NVARCHAR(255) NOT NULL,
+    name_norm NVARCHAR(255) NOT NULL,
+    created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT PK_clients PRIMARY KEY (client_id)
+  );
+END;
+
+-- Índice único por name_norm
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name='UQ_clients_name_norm' AND object_id=OBJECT_ID('dbo.clients'))
+  CREATE UNIQUE INDEX UQ_clients_name_norm ON dbo.clients(name_norm);
+
+-- B) facts_meta: asegurar FK client_id y columna calculada para índice
+IF OBJECT_ID('dbo.facts_meta','U') IS NULL
+BEGIN
+  CREATE TABLE dbo.facts_meta(
+    fact_id BIGINT IDENTITY(1,1) PRIMARY KEY,
+    client_id UNIQUEIDENTIFIER NOT NULL,
+    [date] DATE NOT NULL,
+    ad_id NVARCHAR(100) NULL,
+    campaign_id NVARCHAR(100) NULL,
+    adset_id NVARCHAR(100) NULL,
+    impressions BIGINT NULL,
+    clicks BIGINT NULL,
+    spend DECIMAL(18,4) NULL,
+    purchases INT NULL,
+    roas DECIMAL(18,4) NULL,
+    created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT FK_facts_meta_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id)
+  );
+END
+ELSE
+BEGIN
+  IF COL_LENGTH('dbo.facts_meta','client_id') IS NULL
+    ALTER TABLE dbo.facts_meta ADD client_id UNIQUEIDENTIFIER NULL;
+  -- (si había otra FK, migrar datos acá)
+  IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id=OBJECT_ID('dbo.facts_meta') AND name='client_id')
+    ALTER TABLE dbo.facts_meta ALTER COLUMN client_id UNIQUEIDENTIFIER NOT NULL;
+END;
+
+-- Columna calculada para indexar ISNULL(ad_id,'')
+IF COL_LENGTH('dbo.facts_meta','ad_id_nz') IS NULL
+  ALTER TABLE dbo.facts_meta ADD ad_id_nz AS (ISNULL(ad_id,'')) PERSISTED;
+
+-- Índice único (client_id, date, ad_id_nz)
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name='UX_facts_meta_client_date_ad_nz' AND object_id=OBJECT_ID('dbo.facts_meta'))
+  CREATE UNIQUE INDEX UX_facts_meta_client_date_ad_nz ON dbo.facts_meta(client_id, [date], ad_id_nz);


### PR DESCRIPTION
## Summary
- add idempotent MSSQL migration ensuring client_id GUIDs and unique indexes
- refactor MetaDb adapter to manage GUID clients and separated find/create helpers
- streamline /api/sql/import-excel to confirm client creation and merge META facts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689636878c188332aa0704aee2f74057