### PR TITLE
feat: derive stable ad ids from names

### DIFF
--- a/database/MetaDb.ts
+++ b/database/MetaDb.ts
@@ -192,14 +192,16 @@ SELECT client_id, name, name_norm, created_at FROM @out;`);
         .input('clientId', sql.UniqueIdentifier, row.clientId)
         .input('adId', sql.NVarChar(255), row.adId)
         .input('name', sql.NVarChar(255), row.name)
-        .input('nameNorm', sql.NVarChar(255), row.nameNorm);
+        .input('nameNorm', sql.NVarChar(255), row.nameNorm)
+        .input('prev', sql.NVarChar(sql.MAX), row.adPreviewLink ?? null)
+        .input('thumb', sql.NVarChar(sql.MAX), row.adCreativeThumbnailUrl ?? null);
       const result = await request.query(`
 CREATE TABLE #actions (action NVARCHAR(10));
 MERGE ads AS target
-USING (SELECT @clientId AS client_id, @adId AS ad_id, @name AS name, @nameNorm AS ad_name_norm) AS source
+USING (SELECT @clientId AS client_id, @adId AS ad_id, @name AS name, @nameNorm AS ad_name_norm, @prev AS ad_preview_link, @thumb AS ad_creative_thumbnail_url) AS source
 ON (target.client_id = source.client_id AND target.ad_id = source.ad_id)
-WHEN MATCHED THEN UPDATE SET name = source.name, ad_name_norm = source.ad_name_norm
-WHEN NOT MATCHED THEN INSERT (client_id, ad_id, name, ad_name_norm) VALUES (source.client_id, source.ad_id, source.name, source.ad_name_norm)
+WHEN MATCHED THEN UPDATE SET name = source.name, ad_name_norm = source.ad_name_norm, ad_preview_link = source.ad_preview_link, ad_creative_thumbnail_url = source.ad_creative_thumbnail_url
+WHEN NOT MATCHED THEN INSERT (client_id, ad_id, name, ad_name_norm, ad_preview_link, ad_creative_thumbnail_url) VALUES (source.client_id, source.ad_id, source.name, source.ad_name_norm, source.ad_preview_link, source.ad_creative_thumbnail_url)
 OUTPUT $action INTO #actions;
 SELECT action FROM #actions;
 DROP TABLE #actions;

--- a/importers/importLookerReport.ts
+++ b/importers/importLookerReport.ts
@@ -1,69 +1,59 @@
 import { read, utils } from 'xlsx';
-import { MetaDb, LookerUrlRow } from '../database/MetaDb.js';
+import { MetaDb, MetaAdRow } from '../database/MetaDb.js';
 import normalizeName from '../lib/normalizeName.js';
+import adIdFromName from '../lib/adIdFromName.js';
 import Logger from '../Logger.js';
 
 export interface LookerImportResult {
   total: number;
+  inserted: number;
   updated: number;
-  unmatched: Record<string, string[]>; // account -> identifiers
+  unmatched: string[]; // accounts not found
 }
 
 /**
- * Import Looker report from an ArrayBuffer/Buffer. Updates ad URLs by matching on client + ad_id or ad_name_norm.
+ * Import Looker report from an ArrayBuffer/Buffer. Upserts ads with preview/thumbnail
+ * using ad_id derived from ad name.
  */
 export async function importLookerReport(data: ArrayBuffer, db: MetaDb): Promise<LookerImportResult> {
   const workbook = read(data, { type: 'array' });
-  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const sheet = workbook.Sheets['Hoja 1'] || workbook.Sheets[workbook.SheetNames[0]];
   const rows = utils.sheet_to_json<any>(sheet);
   if (rows.length === 0) {
     Logger.warn('[importLookerReport] No rows in file');
-    return { total: 0, updated: 0, unmatched: {} };
+    return { total: 0, inserted: 0, updated: 0, unmatched: [] };
   }
 
-  const staging: LookerUrlRow[] = [];
-  const unmatched: { account: string; id: string }[] = [];
-  const clientNames: Record<string, string> = {};
+  const staging: MetaAdRow[] = [];
+  const unmatched: string[] = [];
 
   for (const r of rows) {
-    const rawAccount = r['account_name'] || r['Account name'] || r['nombre de la cuenta'] || '';
+    const rawAccount = r['account_name'] || r['Account name'] || r['Account Name'] || r['nombre de la cuenta'] || '';
     const client = await db.findClientByNameNorm(normalizeName(String(rawAccount)));
-    const adId = r['ad_id'] || r['Ad ID'] || r['ad id'];
-    const adName = r['ad_name'] || r['Ad name'] || r['nombre del anuncio'];
-    const adNameNorm = adName ? normalizeName(String(adName)) : undefined;
-    const preview = r['ad_preview_link'] || r['Ad Preview Link'];
-    const thumb = r['ad_creative_thumbnail_url'] || r['Ad Creative Thumbnail Url'];
-    const identifier = adId ? String(adId) : adNameNorm || '';
-
     if (!client) {
-      unmatched.push({ account: String(rawAccount), id: identifier });
+      unmatched.push(String(rawAccount));
       continue;
     }
-    clientNames[client.id] = client.name;
+
+    const adName = r['Ad name'] || r['Ad Name'] || r['Nombre del anuncio'] || '';
+    const adId = adIdFromName(String(adName));
+    const adNameNorm = normalizeName(String(adName));
+    const preview = r['Ad Preview Link'] || r['ad_preview_link'];
+    const thumb = r['Ad Creative Thumbnail Url'] || r['ad_creative_thumbnail_url'];
+
     staging.push({
       clientId: client.id,
-      adId: adId ? String(adId) : undefined,
-      adNameNorm,
+      adId,
+      name: String(adName),
+      nameNorm: adNameNorm,
       adPreviewLink: preview,
       adCreativeThumbnailUrl: thumb,
     });
   }
 
-  const dbResult = await db.updateAdUrls(staging);
-  dbResult.unmatched.forEach(u => {
-    const account = clientNames[u.clientId] || String(u.clientId);
-    const id = u.adId ? u.adId : u.adNameNorm || '';
-    unmatched.push({ account, id });
-  });
-
-  const grouped: Record<string, string[]> = {};
-  unmatched.forEach(u => {
-    if (!grouped[u.account]) grouped[u.account] = [];
-    grouped[u.account].push(u.id);
-  });
-
-  Logger.info(`{importLookerReport} processed=${rows.length} updated=${dbResult.updated} unmatched=${unmatched.length}`);
-  return { total: rows.length, updated: dbResult.updated, unmatched: grouped };
+  const dbResult = await db.upsertAds(staging);
+  Logger.info(`{importLookerReport} processed=${rows.length} inserted=${dbResult.inserted} updated=${dbResult.updated} unmatched=${unmatched.length}`);
+  return { total: rows.length, inserted: dbResult.inserted, updated: dbResult.updated, unmatched };
 }
 
 export default importLookerReport;

--- a/lib/adIdFromName.test.ts
+++ b/lib/adIdFromName.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import adIdFromName from './adIdFromName';
+
+describe('adIdFromName', () => {
+  it('derives deterministic id from normalized name', () => {
+    const raw = '  Ád Prueba  ';
+    const normalized = 'ad prueba';
+    const expectedHash = crypto.createHash('sha1').update(normalized).digest('hex');
+    const expected = `H_${expectedHash}`;
+    expect(adIdFromName(raw)).toBe(expected);
+  });
+
+  it('returns consistent value for same name regardless of casing/spacing', () => {
+    const a = adIdFromName('My Ad Name');
+    const b = adIdFromName('  my   ad name ');
+    expect(a).toBe(b);
+  });
+});

--- a/lib/adIdFromName.ts
+++ b/lib/adIdFromName.ts
@@ -1,0 +1,18 @@
+import { createHash } from 'crypto';
+import normalizeName from './normalizeName.js';
+
+/**
+ * Derive a deterministic ad_id from an ad name.
+ * - Normalizes the name (lowercase, trimmed, collapse spaces, remove diacritics)
+ * - SHA1 hashes the normalized name and prefixes with "H_".
+ *
+ * @param adName Raw ad name string
+ * @returns A stable identifier like "H_<sha1>" (42 chars max)
+ */
+export function adIdFromName(adName: string): string {
+  const nameNorm = normalizeName(adName);
+  const sha1Hex = createHash('sha1').update(nameNorm).digest('hex');
+  return `H_${sha1Hex}`;
+}
+
+export default adIdFromName;


### PR DESCRIPTION
## Summary
- add shared `adIdFromName` utility to derive deterministic ad identifiers
- update Meta and Looker importers to hash ad names into IDs and aggregate metrics
- extend SQL ad upsert to store preview and thumbnail URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689654671f1c8332a6a8813f0c182053