### PR TITLE
feat: derive stable ad ids from names

### DIFF
--- a/database/MetaDb.ts
+++ b/database/MetaDb.ts
@@ -192,14 +192,16 @@ SELECT client_id, name, name_norm, created_at FROM @out;`);
         .input('clientId', sql.UniqueIdentifier, row.clientId)
         .input('adId', sql.NVarChar(255), row.adId)
         .input('name', sql.NVarChar(255), row.name)
-        .input('nameNorm', sql.NVarChar(255), row.nameNorm);
+        .input('nameNorm', sql.NVarChar(255), row.nameNorm)
+        .input('prev', sql.NVarChar(sql.MAX), row.adPreviewLink ?? null)
+        .input('thumb', sql.NVarChar(sql.MAX), row.adCreativeThumbnailUrl ?? null);
       const result = await request.query(`
 CREATE TABLE #actions (action NVARCHAR(10));
 MERGE ads AS target
-USING (SELECT @clientId AS client_id, @adId AS ad_id, @name AS name, @nameNorm AS ad_name_norm) AS source
+USING (SELECT @clientId AS client_id, @adId AS ad_id, @name AS name, @nameNorm AS ad_name_norm, @prev AS ad_preview_link, @thumb AS ad_creative_thumbnail_url) AS source
 ON (target.client_id = source.client_id AND target.ad_id = source.ad_id)
-WHEN MATCHED THEN UPDATE SET name = source.name, ad_name_norm = source.ad_name_norm
-WHEN NOT MATCHED THEN INSERT (client_id, ad_id, name, ad_name_norm) VALUES (source.client_id, source.ad_id, source.name, source.ad_name_norm)
+WHEN MATCHED THEN UPDATE SET name = source.name, ad_name_norm = source.ad_name_norm, ad_preview_link = source.ad_preview_link, ad_creative_thumbnail_url = source.ad_creative_thumbnail_url
+WHEN NOT MATCHED THEN INSERT (client_id, ad_id, name, ad_name_norm, ad_preview_link, ad_creative_thumbnail_url) VALUES (source.client_id, source.ad_id, source.name, source.ad_name_norm, source.ad_preview_link, source.ad_creative_thumbnail_url)
 OUTPUT $action INTO #actions;
 SELECT action FROM #actions;
 DROP TABLE #actions;

--- a/lib/adIdFromName.test.ts
+++ b/lib/adIdFromName.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import adIdFromName from './adIdFromName';
+
+describe('adIdFromName', () => {
+  it('derives deterministic id from normalized name', () => {
+    const raw = '  Ád Prueba  ';
+    const normalized = 'ad prueba';
+    const expectedHash = crypto.createHash('sha1').update(normalized).digest('hex');
+    const expected = `H_${expectedHash}`;
+    expect(adIdFromName(raw)).toBe(expected);
+  });
+
+  it('returns consistent value for same name regardless of casing/spacing', () => {
+    const a = adIdFromName('My Ad Name');
+    const b = adIdFromName('  my   ad name ');
+    expect(a).toBe(b);
+  });
+});

--- a/lib/adIdFromName.ts
+++ b/lib/adIdFromName.ts
@@ -1,0 +1,18 @@
+import { createHash } from 'crypto';
+import normalizeName from './normalizeName.js';
+
+/**
+ * Derive a deterministic ad_id from an ad name.
+ * - Normalizes the name (lowercase, trimmed, collapse spaces, remove diacritics)
+ * - SHA1 hashes the normalized name and prefixes with "H_".
+ *
+ * @param adName Raw ad name string
+ * @returns A stable identifier like "H_<sha1>" (42 chars max)
+ */
+export function adIdFromName(adName: string): string {
+  const nameNorm = normalizeName(adName);
+  const sha1Hex = createHash('sha1').update(nameNorm).digest('hex');
+  return `H_${sha1Hex}`;
+}
+
+export default adIdFromName;


### PR DESCRIPTION
## Summary
- add shared `adIdFromName` utility to derive deterministic ad identifiers
- update Meta and Looker importers to hash ad names into IDs and aggregate metrics
- extend SQL ad upsert to store preview and thumbnail URLs
- dedupe unmatched Looker accounts and fix log prefix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689654671f1c8332a6a8813f0c182053