### PR TITLE
feat: enhance SQL import handling and diagnostics

### DIFF
--- a/components/ImportView.tsx
+++ b/components/ImportView.tsx
@@ -493,6 +493,9 @@ export const ImportView: React.FC<ImportViewProps> = ({
             updatedHashes[clientId] = [...(updatedHashes[clientId] || []), fileHash];
             await db.saveProcessedHashes(updatedHashes);
 
+            await refreshClients();
+            await refreshPerformance();
+
         } catch (error) {
             const message = error instanceof Error ? error.message : "Error desconocido.";
             setFeedback({ type: 'error', message: `Error al procesar el reporte TXT: ${message}` });

--- a/components/SqlConnectionPanel.tsx
+++ b/components/SqlConnectionPanel.tsx
@@ -175,9 +175,8 @@ export const SqlConnectionPanel: React.FC = () => {
         Logger.info('[SQL][EnsureSchema] start');
         try {
             const data = await fetchJson('/api/sql/ensure-schema', { method: 'POST' });
-            if (data.actions) {
-                const summary = data.actions.map((a: any) => `${a.table}:${a.action}`).join(', ');
-                setMessage(summary || 'Esquema verificado');
+            if (data.ok) {
+                setMessage('Esquema verificado');
             } else if (data.error) {
                 setMessage(data.error);
             } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "mysql2": "^3.14.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "uuid": "^9.0.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mysql2": "^3.14.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "uuid": "^9.0.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- ensure schema on SQL connect and expose cleanup for staging
- merge META imports via persistent staging with derived ad IDs
- refresh client data after TXT imports and streamline ensure-schema button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689662da3b048332b3125fd35dc3890f