### PR TITLE
fix: update import history query

### DIFF
--- a/server.js
+++ b/server.js
@@ -816,7 +816,7 @@ app.get('/api/sql/import-history', async (req, res) => {
     }
     try {
         const result = await sqlPool.request().query(`
-SELECT id, source, COALESCE(batch_data, payload) AS batch_data, created_at
+SELECT id, source, batch_data, created_at
 FROM dbo.import_history
 ORDER BY id DESC;
         `);


### PR DESCRIPTION
## Summary
- remove legacy payload column from import history endpoint
- query batch_data directly from dbo.import_history

## Testing
- `npm test`
- `curl -i http://localhost:3001/api/sql/import-history`

------
https://chatgpt.com/codex/tasks/task_e_689a08b915e48332abed7922c2a25386