### PR TITLE
fix: streamline Meta Excel import try block

### DIFF
--- a/server.js
+++ b/server.js
@@ -782,15 +782,6 @@ SELECT client_id FROM @out;`);
 
         await bulkInsertRows(facts);
 
-        }
-        try {
-            await sqlPool.request().bulk(table);
-        } catch (err) {
-            logger.error(`[SQL][ImportMeta] Bulk insert failed`, { sessionId, rows: facts.length, error: err });
-            return res.status(500).json({ success: false, error: err.message, sessionId });
-        }
-
-
         const mergeRes = await sqlPool
             .request()
             .input('P_session_id', sql.UniqueIdentifier, sessionId)


### PR DESCRIPTION
## Summary
- remove stray closing brace and redundant bulk insert try/catch
- keep merge logic within original try block of import API

## Testing
- `npm test`
- `npm run server`

------
https://chatgpt.com/codex/tasks/task_e_689a217c93a08332aa1748d495cac5f6