### PR TITLE
Add synthetic ad ID generator and meta import docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Para verificar el nuevo flujo de importación de reportes de Meta:
 2. Caso 1: si el `account_name` no existe, al importar se crea un nuevo cliente y se insertan las métricas.
 3. Caso 2: si el cliente ya existe, se actualizan o insertan métricas sin duplicados gracias al índice `(client_id,date,ad_id)`.
 4. Reimportar el mismo archivo no debe generar filas duplicadas; el log mostrará conteos de filas insertadas y actualizadas.
+### Cómo ejecutar importación de Meta
+
+Desde la línea de comandos:
+
+```
+npm run import:meta -- --file "path.xlsx" --client "<GUID>"
+```
+
+Endpoint HTTP:
+
+```
+POST /api/import/meta?client_id=<GUID>
+```
+
 
 ## Número de compilación
 

--- a/db/migrations/20250101_meta.sql
+++ b/db/migrations/20250101_meta.sql
@@ -1,0 +1,16 @@
+-- Schema changes for Meta report import
+ALTER TABLE metricas
+  ALTER COLUMN públicos_personalizados_incluidos NVARCHAR(MAX),
+  ALTER COLUMN públicos_personalizados_excluidos NVARCHAR(MAX);
+
+ALTER TABLE metricas
+  ALTER COLUMN ad_preview_link NVARCHAR(512),
+  ALTER COLUMN ad_creative_thumbnail_url NVARCHAR(512);
+
+ALTER TABLE metricas
+  ADD CONSTRAINT UQ_metricas_reporte UNIQUE(id_reporte, unique_id);
+
+ALTER TABLE ads ADD is_synthetic BIT NOT NULL DEFAULT(0);
+
+CREATE UNIQUE INDEX UX_facts_meta_client_date_ad ON facts_meta(client_id, [date], ad_id);
+CREATE UNIQUE INDEX UX_ads_client_name_norm ON ads(client_id, ad_name_norm);

--- a/services/idsResolver.test.ts
+++ b/services/idsResolver.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { synthAdId } from './idsResolver.js';
+
+describe('idsResolver', () => {
+  it('generates deterministic negative synthetic ids', () => {
+    const id1 = synthAdId('acct', 'camp', 'set', 'ad');
+    const id2 = synthAdId('acct', 'camp', 'set', 'ad');
+    expect(id1).toBe(id2);
+    expect(typeof id1).toBe('bigint');
+    expect(id1 < 0n).toBe(true);
+  });
+});

--- a/services/idsResolver.ts
+++ b/services/idsResolver.ts
@@ -1,0 +1,21 @@
+import { createHash } from 'crypto';
+
+/**
+ * Generate a deterministic synthetic ad_id when the real ID is missing.
+ * The result is always a negative BIGINT computed from a 64-bit hash of
+ * account, campaign, adset and ad names.
+ */
+export function synthAdId(
+  accountName: string = '',
+  campaign: string = '',
+  adset: string = '',
+  ad: string = ''
+): bigint {
+  const input = `${accountName}|${campaign}|${adset}|${ad}`;
+  // Use SHA-256 and keep the first 8 bytes (64 bits)
+  const hex = createHash('sha256').update(input).digest('hex').slice(0, 16);
+  const positive = BigInt('0x' + hex) & ((1n << 63n) - 1n); // 63-bit positive number
+  return -positive; // Always negative
+}
+
+export default { synthAdId };


### PR DESCRIPTION
## Summary
- add deterministic negative synthetic ad ID helper
- document Meta import CLI and HTTP usage
- include SQL migration for Meta reporting tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2499b0948332a54292792762f4e4