### PR TITLE
feat: improve Meta report ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Para verificar el nuevo flujo de importación de reportes de Meta:
 2. Caso 1: si el `account_name` no existe, al importar se crea un nuevo cliente y se insertan las métricas.
 3. Caso 2: si el cliente ya existe, se actualizan o insertan métricas sin duplicados gracias al índice `(client_id,date,ad_id)`.
 4. Reimportar el mismo archivo no debe generar filas duplicadas; el log mostrará conteos de filas insertadas y actualizadas.
+
+El importador acepta ahora cabeceras en español como "Día" o "Nombre del anuncio" y, si falta el `ad_id`, genera uno sintético a partir de los nombres de cuenta, campaña, conjunto y anuncio.
 ### Cómo ejecutar importación de Meta
 
 Desde la línea de comandos:

--- a/build-info.ts
+++ b/build-info.ts
@@ -1,1 +1,1 @@
-export const BUILD_NUMBER = 3;
+export const BUILD_NUMBER = 4;

--- a/importers/importMetaReport.ts
+++ b/importers/importMetaReport.ts
@@ -2,9 +2,10 @@ import { read, utils } from 'xlsx';
 import { createInterface } from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { MetaDb, MetaMetricRow, MetaAdRow } from '../database/MetaDb.js';
-import normalizeName from '../lib/normalizeName.js';
-import adIdFromName from '../lib/adIdFromName.js';
 import Logger from '../Logger.js';
+import { dedupeHeaders, HEADER_MAP } from '../lib/headerNormalizer.js';
+import { toDateISO, toNumberES, normName } from '../lib/valueParsers.js';
+import { synthAdId } from '../services/idsResolver.js';
 
 /**
  * Import Meta report from an ArrayBuffer/Buffer. Parses Excel, creates/uses client, and upserts metrics.
@@ -12,16 +13,26 @@ import Logger from '../Logger.js';
 export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
   const workbook = read(data, { type: 'array' });
   const sheet = workbook.Sheets['Raw Data Report'] || workbook.Sheets[workbook.SheetNames[0]];
-  const rows = utils.sheet_to_json<any>(sheet);
+  const rows = utils.sheet_to_json<any[]>(sheet, { header: 1, defval: null });
 
-  if (rows.length === 0) {
+  if (rows.length < 2) {
     Logger.warn('[importMetaReport] No rows in file');
-    return { total: 0, inserted: 0, updated: 0, skipped: 0 };
+    return { parsed: 0, valid: 0, missing_date: 0, missing_ad_name: 0 };
   }
 
-  const first = rows[0];
-  const rawName = first['account_name'] || first['Account name'] || first['nombre de la cuenta'] || '';
-  const nameNorm = normalizeName(String(rawName));
+  const headerRow = rows[0].map(h => String(h ?? ''));
+  const dataRows = rows.slice(1);
+
+  const normalized = dedupeHeaders(headerRow);
+  const canonical = normalized.map(h => HEADER_MAP[h] ?? h);
+
+  // prepare first row to resolve client
+  const firstObj: any = {};
+  for (let i = 0; i < canonical.length; i++) {
+    firstObj[canonical[i]] = dataRows[0][i];
+  }
+  const rawName = firstObj['account_name'] || '';
+  const nameNorm = normName(String(rawName));
   let client = await db.findClientByNameNorm(nameNorm);
   if (!client) {
     const rl = createInterface({ input, output });
@@ -29,7 +40,7 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
     rl.close();
     if (answer !== 'y') {
       Logger.warn('[importMetaReport] Aborted import - client not created');
-      return { total: 0, inserted: 0, updated: 0, skipped: rows.length };
+      return { parsed: 0, valid: 0, missing_date: 0, missing_ad_name: 0 };
     }
     client = { id: '', name: String(rawName), nameNorm, logo: '', currency: '', userId: '' };
     const id = await db.createClient({ name: client.name, nameNorm });
@@ -37,40 +48,38 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
     Logger.info(`[importMetaReport] Created client ${client.name} (${id})`);
   }
 
-  const agg: Map<string, { row: MetaMetricRow; purchase_value: number }> = new Map();
+  const agg: Map<string, { row: MetaMetricRow; value: number }> = new Map();
   const adMap: Map<string, MetaAdRow> = new Map();
-  let discarded = 0;
+  let parsed = 0;
+  let valid = 0;
+  let missing_date = 0;
+  let missing_ad_name = 0;
+  const examples: Record<string, any> = {};
 
-  const parseDate = (val: any) => {
-    if (!val) return '';
-    const parts = String(val).split(/[-\/]/);
-    if (parts.length === 3) {
-      const [d, m, y] = parts;
-      const year = y.length === 2 ? `20${y}` : y;
-      return `${year.padStart(4, '0')}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+  for (const arr of dataRows) {
+    parsed++;
+    const obj: any = {};
+    for (let i = 0; i < canonical.length; i++) {
+      const key = canonical[i];
+      obj[key] = arr[i];
     }
-    const dt = new Date(val);
-    if (!isNaN(dt.getTime())) return dt.toISOString().slice(0, 10);
-    return '';
-  };
-
-  const parseNum = (v: any): number => {
-    if (v === undefined || v === null || v === '') return 0;
-    if (typeof v === 'number') return v;
-    const cleaned = String(v).replace(/[€$,]/g, '').replace(/\./g, '').replace(/,/g, '.');
-    const num = parseFloat(cleaned);
-    return isNaN(num) ? 0 : num;
-  };
-
-  for (const r of rows) {
-    const rawDate = r['Día'] ?? r['day'] ?? r['date'];
-    const adName = r['Nombre del anuncio'] ?? r['Ad name'] ?? r['ad_name'];
-    if (!rawDate || !adName) {
-      discarded++;
+    const date = toDateISO(obj['date']);
+    const adName = obj['ad_name'];
+    if (!date) {
+      missing_date++;
+      if (!examples.missing_date) examples.missing_date = obj;
       continue;
     }
-    const date = parseDate(rawDate);
-    const adId = adIdFromName(String(adName));
+    if (!adName) {
+      missing_ad_name++;
+      if (!examples.missing_ad_name) examples.missing_ad_name = obj;
+      continue;
+    }
+    valid++;
+    const account = obj['account_name'];
+    const campaign = obj['campaign_name'];
+    const adset = obj['adset_name'];
+    const adId = obj['ad_id'] ? String(obj['ad_id']) : synthAdId(account, campaign, adset, adName).toString();
 
     const key = `${date}|${adId}`;
     if (!agg.has(key)) {
@@ -85,21 +94,21 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
           purchases: 0,
           roas: null,
         },
-        purchase_value: 0,
+        value: 0,
       });
     }
     const entry = agg.get(key)!;
-    entry.row.impressions! += parseNum(r['Impresiones']);
-    entry.row.clicks! += parseNum(r['Clics en el enlace'] ?? r['Clics (todos)']);
-    entry.row.spend! += parseNum(r['Importe gastado (EUR)']);
-    entry.row.purchases! += parseNum(r['Compras']);
-    entry.purchase_value += parseNum(r['Valor de conversión de compras']);
+    entry.row.impressions! += toNumberES(obj['impressions']) ?? 0;
+    entry.row.clicks! += toNumberES(obj['clicks']) ?? 0;
+    entry.row.spend! += toNumberES(obj['spend']) ?? 0;
+    entry.row.purchases! += toNumberES(obj['purchases']) ?? 0;
+    entry.value += toNumberES(obj['value']) ?? 0;
 
     const adRow: MetaAdRow = {
       clientId: client.id,
       adId,
       name: String(adName),
-      nameNorm: normalizeName(String(adName)),
+      nameNorm: normName(String(adName)),
     };
     const adKey = `${adRow.clientId}-${adRow.adId}`;
     if (!adMap.has(adKey)) adMap.set(adKey, adRow);
@@ -107,15 +116,17 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
 
   const metricRows: MetaMetricRow[] = [];
   agg.forEach(v => {
-    if (v.row.spend && v.row.spend > 0 && v.purchase_value) {
-      v.row.roas = v.purchase_value / (v.row.spend ?? 1);
+    if (v.row.spend && v.row.spend > 0 && v.value) {
+      v.row.roas = v.value / (v.row.spend ?? 1);
     }
     metricRows.push(v.row);
   });
 
   const adsResult = await db.upsertAds([...adMap.values()]);
   const result = await db.upsertMetaMetrics(metricRows);
-  Logger.info(`[importMetaReport] processed=${metricRows.length} inserted=${result.inserted} updated=${result.updated} skipped=${discarded} adsIns=${adsResult.inserted} adsUpd=${adsResult.updated}`);
-  return { total: metricRows.length, inserted: result.inserted, updated: result.updated, skipped: discarded };
+  Logger.info(
+    `[importMetaReport] parsed=${parsed} valid=${valid} missing_date=${missing_date} missing_ad_name=${missing_ad_name} inserted=${result.inserted} updated=${result.updated} adsIns=${adsResult.inserted} adsUpd=${adsResult.updated}`
+  );
+  return { parsed, valid, missing_date, missing_ad_name };
 }
 export default importMetaReport;

--- a/lib/headerNormalizer.test.ts
+++ b/lib/headerNormalizer.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { dedupeHeaders, normalize } from './headerNormalizer.js';
+import { dedupeHeaders, normHeader } from './headerNormalizer.js';
 
 describe('headerNormalizer', () => {
   it('normalizes headers', () => {
-    expect(normalize('Impresiones')).toBe('impresiones');
-    expect(normalize('CPC (todos)')).toBe('cpc_todos');
+    expect(normHeader('Impresiones')).toBe('impresiones');
+    expect(normHeader('CPC (todos)')).toBe('cpc todos');
   });
 
   it('handles compras vs % compras', () => {

--- a/lib/headerNormalizer.ts
+++ b/lib/headerNormalizer.ts
@@ -1,4 +1,4 @@
-export function normalize(header: string): string {
+export function normHeader(header: string): string {
   if (!header) return '';
   return header
     .normalize('NFD')
@@ -6,13 +6,13 @@ export function normalize(header: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, ' ')
     .trim()
-    .replace(/\s+/g, '_');
+    .replace(/\s+/g, ' ');
 }
 
 export function dedupeHeaders(headers: string[]): string[] {
   const seen = new Map<string, number>();
   return headers.map(h => {
-    let norm = normalize(h);
+    let norm = normHeader(h);
     if (norm === 'compras' && /%/.test(h)) {
       norm = 'compras_pct';
     }
@@ -27,4 +27,23 @@ export function dedupeHeaders(headers: string[]): string[] {
   });
 }
 
-export default { normalize, dedupeHeaders };
+export const HEADER_MAP: Record<string, string> = {
+  'nombre de la campaña': 'campaign_name',
+  'nombre del conjunto de anuncios': 'adset_name',
+  'nombre del anuncio': 'ad_name',
+  dia: 'date',
+  'importe gastado eur': 'spend',
+  impresiones: 'impressions',
+  'clics todos': 'clicks',
+  'cpc todos': 'cpc',
+  'cpm costo por mil impresiones': 'cpm',
+  'ctr todos': 'ctr',
+  'valor de conversion de compras': 'value',
+  compras: 'purchases',
+  'compras_pct': 'purchases_pct',
+  'visitas a la pagina de destino': 'lpv',
+  'pagos iniciados': 'init_checkout',
+  'nombre de la cuenta': 'account_name',
+};
+
+export default { normHeader, dedupeHeaders, HEADER_MAP };

--- a/lib/valueParsers.test.ts
+++ b/lib/valueParsers.test.ts
@@ -14,4 +14,8 @@ describe('valueParsers', () => {
     expect(toPct('5,43')).toBeCloseTo(0.0543);
     expect(toPct('0,54')).toBeCloseTo(0.54);
   });
+
+  it('returns null for non-finite numbers', () => {
+    expect(toNumberES('Infinity')).toBeNull();
+  });
 });

--- a/lib/valueParsers.ts
+++ b/lib/valueParsers.ts
@@ -20,13 +20,13 @@ export function toDateISO(val: any): string | null {
 
 export function toNumberES(val: any): number | null {
   if (val === null || val === undefined || val === '') return null;
-  if (typeof val === 'number') return val;
+  if (typeof val === 'number') return isFinite(val) ? val : null;
   const cleaned = String(val)
     .replace(/[\s€$]/g, '')
     .replace(/\./g, '')
     .replace(/,/g, '.');
   const num = parseFloat(cleaned);
-  return isNaN(num) ? null : num;
+  return isFinite(num) ? num : null;
 }
 
 export function toPct(val: any): number | null {


### PR DESCRIPTION
## Summary
- normalize and remap Spanish Meta report headers before validation
- parse European numbers safely and ignore non-finite values
- ingest Meta reports using synthetic ad ids when missing and log validation counters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4fb69d088332a0b3c617996c53d3