### PR TITLE
feat: handle spanish meta imports with staging merge

### DIFF
--- a/importers/importMetaReport.ts
+++ b/importers/importMetaReport.ts
@@ -3,14 +3,20 @@ import { createInterface } from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { MetaDb, MetaMetricRow, MetaAdRow } from '../database/MetaDb.js';
 import Logger from '../Logger.js';
-import { dedupeHeaders, HEADER_MAP } from '../lib/headerNormalizer.js';
-import { toDateISO, toNumberES, normName } from '../lib/valueParsers.js';
+import { mapHeaders } from '../lib/headerNormalizer.js';
+import { toDateISO, toNumberES, normName, toPct } from '../lib/valueParsers.js';
 import { synthAdId } from '../services/idsResolver.js';
+import crypto from 'crypto';
 
 /**
  * Import Meta report from an ArrayBuffer/Buffer. Parses Excel, creates/uses client, and upserts metrics.
  */
 export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
+  const hash = crypto.createHash('sha256').update(Buffer.from(data)).digest('hex');
+  if (await db.hasFileHash(hash)) {
+    Logger.info('[importMetaReport] File already processed');
+    return { parsed: 0, valid: 0, missing_date: 0, missing_ad_name: 0 };
+  }
   const workbook = read(data, { type: 'array' });
   const sheet = workbook.Sheets['Raw Data Report'] || workbook.Sheets[workbook.SheetNames[0]];
   const rows = utils.sheet_to_json<any[]>(sheet, { header: 1, defval: null });
@@ -23,8 +29,7 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
   const headerRow = rows[0].map(h => String(h ?? ''));
   const dataRows = rows.slice(1);
 
-  const normalized = dedupeHeaders(headerRow);
-  const canonical = normalized.map(h => HEADER_MAP[h] ?? h);
+  const canonical = mapHeaders(headerRow);
 
   // prepare first row to resolve client
   const firstObj: any = {};
@@ -48,12 +53,13 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
     Logger.info(`[importMetaReport] Created client ${client.name} (${id})`);
   }
 
-  const agg: Map<string, { row: MetaMetricRow; value: number }> = new Map();
   const adMap: Map<string, MetaAdRow> = new Map();
+  const stagingRows: MetaMetricRow[] = [];
   let parsed = 0;
   let valid = 0;
   let missing_date = 0;
   let missing_ad_name = 0;
+  let synthetic_ad_id = 0;
   const examples: Record<string, any> = {};
 
   for (const arr of dataRows) {
@@ -63,7 +69,14 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
       const key = canonical[i];
       obj[key] = arr[i];
     }
-    const date = toDateISO(obj['date']);
+
+    obj['date'] = toDateISO(obj['date']);
+    for (const k of Object.keys(obj)) {
+      if (k.endsWith('_pct')) obj[k] = toPct(obj[k]);
+      else if (['impressions', 'clicks', 'spend', 'purchases', 'value'].includes(k)) obj[k] = toNumberES(obj[k]);
+    }
+
+    const date = obj['date'];
     const adName = obj['ad_name'];
     if (!date) {
       missing_date++;
@@ -75,34 +88,27 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
       if (!examples.missing_ad_name) examples.missing_ad_name = obj;
       continue;
     }
-    valid++;
-    const account = obj['account_name'];
-    const campaign = obj['campaign_name'];
-    const adset = obj['adset_name'];
-    const adId = obj['ad_id'] ? String(obj['ad_id']) : synthAdId(account, campaign, adset, adName).toString();
-
-    const key = `${date}|${adId}`;
-    if (!agg.has(key)) {
-      agg.set(key, {
-        row: {
-          clientId: client.id,
-          date,
-          adId,
-          impressions: 0,
-          clicks: 0,
-          spend: 0,
-          purchases: 0,
-          roas: null,
-        },
-        value: 0,
-      });
+    const account = obj['account_name'] ?? '';
+    const campaign = obj['campaign_name'] ?? '';
+    const adset = obj['adset_name'] ?? '';
+    let adId = obj['ad_id'] ? String(obj['ad_id']) : '';
+    if (!adId) {
+      adId = synthAdId(account, campaign, adset, adName).toString();
+      synthetic_ad_id++;
     }
-    const entry = agg.get(key)!;
-    entry.row.impressions! += toNumberES(obj['impressions']) ?? 0;
-    entry.row.clicks! += toNumberES(obj['clicks']) ?? 0;
-    entry.row.spend! += toNumberES(obj['spend']) ?? 0;
-    entry.row.purchases! += toNumberES(obj['purchases']) ?? 0;
-    entry.value += toNumberES(obj['value']) ?? 0;
+    obj['ad_id'] = adId; // ensure in examples
+    valid++;
+
+    stagingRows.push({
+      clientId: client.id,
+      date,
+      adId,
+      impressions: obj['impressions'],
+      clicks: obj['clicks'],
+      spend: obj['spend'],
+      purchases: obj['purchases'],
+      value: obj['value'],
+    });
 
     const adRow: MetaAdRow = {
       clientId: client.id,
@@ -114,19 +120,16 @@ export async function importMetaReport(data: ArrayBuffer, db: MetaDb) {
     if (!adMap.has(adKey)) adMap.set(adKey, adRow);
   }
 
-  const metricRows: MetaMetricRow[] = [];
-  agg.forEach(v => {
-    if (v.row.spend && v.row.spend > 0 && v.value) {
-      v.row.roas = v.value / (v.row.spend ?? 1);
-    }
-    metricRows.push(v.row);
-  });
-
   const adsResult = await db.upsertAds([...adMap.values()]);
-  const result = await db.upsertMetaMetrics(metricRows);
+  const stagingInserted = await db.bulkInsertStaging(stagingRows);
+  const mergeResult = await db.mergeFromStaging(client.id);
+  await db.saveFileHash(hash);
+
   Logger.info(
-    `[importMetaReport] parsed=${parsed} valid=${valid} missing_date=${missing_date} missing_ad_name=${missing_ad_name} inserted=${result.inserted} updated=${result.updated} adsIns=${adsResult.inserted} adsUpd=${adsResult.updated}`
+    `[importMetaReport] parsed=${parsed} valid=${valid} missing_date=${missing_date} missing_ad_name=${missing_ad_name} synthetic_ad_id=${synthetic_ad_id} staging_rows_inserted=${stagingInserted} merge_rows_ready=${mergeResult.ready} merge_inserted=${mergeResult.inserted} merge_updated=${mergeResult.updated} adsIns=${adsResult.inserted} adsUpd=${adsResult.updated}`
   );
+  if (examples.missing_date) Logger.info('[importMetaReport] example missing_date', examples.missing_date);
+  if (examples.missing_ad_name) Logger.info('[importMetaReport] example missing_ad_name', examples.missing_ad_name);
   return { parsed, valid, missing_date, missing_ad_name };
 }
 export default importMetaReport;

--- a/lib/headerNormalizer.test.ts
+++ b/lib/headerNormalizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { dedupeHeaders, normHeader } from './headerNormalizer.js';
+import { mapHeaders, normHeader } from './headerNormalizer.js';
 
 describe('headerNormalizer', () => {
   it('normalizes headers', () => {
@@ -7,13 +7,18 @@ describe('headerNormalizer', () => {
     expect(normHeader('CPC (todos)')).toBe('cpc todos');
   });
 
-  it('handles compras vs % compras', () => {
-    const res = dedupeHeaders(['Compras', '% Compras']);
-    expect(res).toEqual(['compras', 'compras_pct']);
+  it('maps and dedupes headers with accents', () => {
+    const res = mapHeaders(['Nombre de la campaña', 'Nombre de la campana']);
+    expect(res).toEqual(['campaign_name', 'campaign_name_2']);
   });
 
-  it('dedupes repeated headers', () => {
-    const res = dedupeHeaders(['foo', 'Foo']);
-    expect(res).toEqual(['foo', 'foo_2']);
+  it('handles compras vs % compras', () => {
+    const res = mapHeaders(['Compras', '% Compras']);
+    expect(res).toEqual(['purchases', 'purchases_pct']);
+  });
+
+  it('dedupes after mapping', () => {
+    const res = mapHeaders(['Compras', 'Compras']);
+    expect(res).toEqual(['purchases', 'purchases_2']);
   });
 });

--- a/lib/headerNormalizer.ts
+++ b/lib/headerNormalizer.ts
@@ -8,42 +8,34 @@ export function normHeader(header: string): string {
     .trim()
     .replace(/\s+/g, ' ');
 }
-
-export function dedupeHeaders(headers: string[]): string[] {
-  const seen = new Map<string, number>();
-  return headers.map(h => {
-    let norm = normHeader(h);
-    if (norm === 'compras' && /%/.test(h)) {
-      norm = 'compras_pct';
-    }
-    if (seen.has(norm)) {
-      const count = (seen.get(norm) || 0) + 1;
-      seen.set(norm, count);
-      norm = `${norm}_${count}`;
-    } else {
-      seen.set(norm, 1);
-    }
-    return norm;
-  });
-}
-
 export const HEADER_MAP: Record<string, string> = {
-  'nombre de la campaña': 'campaign_name',
-  'nombre del conjunto de anuncios': 'adset_name',
+  'dia': 'date',
+  'nombre de la cuenta': 'account_name',
   'nombre del anuncio': 'ad_name',
-  dia: 'date',
+  'nombre del conjunto de anuncios': 'adset_name',
+  'nombre de la campana': 'campaign_name',
   'importe gastado eur': 'spend',
-  impresiones: 'impressions',
+  'impresiones': 'impressions',
   'clics todos': 'clicks',
   'cpc todos': 'cpc',
   'cpm costo por mil impresiones': 'cpm',
   'ctr todos': 'ctr',
   'valor de conversion de compras': 'value',
-  compras: 'purchases',
-  'compras_pct': 'purchases_pct',
+  'compras': 'purchases',
+  '% compras': 'purchases_pct',
   'visitas a la pagina de destino': 'lpv',
   'pagos iniciados': 'init_checkout',
-  'nombre de la cuenta': 'account_name',
 };
+export function mapHeaders(headers: string[]): string[] {
+  const seen = new Map<string, number>();
+  return headers.map(h => {
+    const n = normHeader(h);
+    let k = HEADER_MAP[n] ?? n;
+    if (k === 'purchases' && /%/.test(h)) k = 'purchases_pct';
+    const c = (seen.get(k) ?? 0) + 1;
+    seen.set(k, c);
+    return c === 1 ? k : `${k}_${c}`;
+  });
+}
 
-export default { normHeader, dedupeHeaders, HEADER_MAP };
+export default { normHeader, mapHeaders, HEADER_MAP };

--- a/server.js
+++ b/server.js
@@ -907,7 +907,13 @@ END CATCH;`);
 
         const inserted = resRow.inserted || 0;
         const updated = resRow.updated || 0;
-        logger.info(`[SQL][ImportMeta] account="${accountName}" client_id=${clientId} session_id=${sessionId} total_rows=${rows.length} valid=${facts.length} skipped=${skippedRows} inserted=${inserted} updated=${updated}`);
+        const summary =
+            `[SQL][ImportMeta] account="${accountName}" client_id=${clientId} session_id=${sessionId} total_rows=${rows.length} ` +
+            ` valid=${facts.length} skipped=${skippedRows} ` +
+            `missing_date=${missing_date} missing_ad_name=${missing_ad_name} ad_id_too_long=${ad_id_too_long} ` +
+            `invalid_impressions=${invalid_impressions} invalid_clicks=${invalid_clicks} invalid_purchases=${invalid_purchases} ` +
+            `invalid_spend=${invalid_spend} invalid_purchase_value=${invalid_purchase_value} inserted=${inserted} updated=${updated}`;
+        logger.info(summary);
 
         await sqlPool
             .request()


### PR DESCRIPTION
## Summary
- normalize spanish headers and map after dedupe
- import meta reports with hashing, staging tables and synthetic IDs
- support staging merge and file hash tracking in MetaDb
- detail skipped row reasons in SQL import log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a68fc9dd48332aacac593e52dc1ec