### PR TITLE
feat: expand meta import capabilities

### DIFF
--- a/lib/headerNormalizer.test.ts
+++ b/lib/headerNormalizer.test.ts
@@ -17,6 +17,25 @@ describe('headerNormalizer', () => {
     expect(res).toEqual(['purchases', 'purchases_pct']);
   });
 
+  it('maps additional spanish headers to canonical names', () => {
+    const res = mapHeaders([
+      'Divisa',
+      'Visitas a la página de destino',
+      'Pagos iniciados',
+      'CTR porcentaje de clics en el enlace',
+      'CTR único porcentaje de clics en el enlace',
+      'Porcentaje de Compras',
+    ]);
+    expect(res).toEqual([
+      'currency_code',
+      'landing_page_views',
+      'initiate_checkout',
+      'ctr_link_pct',
+      'unique_ctr_link_pct',
+      'purchases_pct',
+    ]);
+  });
+
   it('dedupes after mapping', () => {
     const res = mapHeaders(['Compras', 'Compras']);
     expect(res).toEqual(['purchases', 'purchases_2']);

--- a/lib/headerNormalizer.ts
+++ b/lib/headerNormalizer.ts
@@ -23,8 +23,12 @@ export const HEADER_MAP: Record<string, string> = {
   'valor de conversion de compras': 'value',
   'compras': 'purchases',
   '% compras': 'purchases_pct',
-  'visitas a la pagina de destino': 'lpv',
-  'pagos iniciados': 'init_checkout',
+  'porcentaje de compras': 'purchases_pct',
+  'visitas a la pagina de destino': 'landing_page_views',
+  'pagos iniciados': 'initiate_checkout',
+  'divisa': 'currency_code',
+  'ctr porcentaje de clics en el enlace': 'ctr_link_pct',
+  'ctr unico porcentaje de clics en el enlace': 'unique_ctr_link_pct',
 };
 export function mapHeaders(headers: string[]): string[] {
   const seen = new Map<string, number>();

--- a/lib/valueParsers.test.ts
+++ b/lib/valueParsers.test.ts
@@ -10,6 +10,10 @@ describe('valueParsers', () => {
     expect(toDateISO('31/07/2025')).toBe('2025-07-31');
   });
 
+  it('rejects unsupported date formats', () => {
+    expect(toDateISO('07-31-2025')).toBeNull();
+  });
+
   it('parses percentages', () => {
     expect(toPct('5,43')).toBeCloseTo(0.0543);
     expect(toPct('0,54')).toBeCloseTo(0.54);

--- a/lib/valueParsers.ts
+++ b/lib/valueParsers.ts
@@ -14,8 +14,7 @@ export function toDateISO(val: any): string | null {
     if (year.length === 2) year = `20${year}`;
     return `${year}-${month}-${day}`;
   }
-  const dt = new Date(str);
-  return isNaN(dt.getTime()) ? null : dt.toISOString().slice(0, 10);
+  return null;
 }
 
 export function toNumberES(val: any): number | null {

--- a/services/idsResolver.test.ts
+++ b/services/idsResolver.test.ts
@@ -9,4 +9,10 @@ describe('idsResolver', () => {
     expect(typeof id1).toBe('bigint');
     expect(id1 < 0n).toBe(true);
   });
+
+  it('is case-insensitive', () => {
+    const id1 = synthAdId('Acct', 'Camp', 'Set', 'Ad');
+    const id2 = synthAdId('acct', 'camp', 'set', 'ad');
+    expect(id1).toBe(id2);
+  });
 });

--- a/services/idsResolver.ts
+++ b/services/idsResolver.ts
@@ -11,7 +11,7 @@ export function synthAdId(
   adset: string = '',
   ad: string = ''
 ): bigint {
-  const input = `${accountName}|${campaign}|${adset}|${ad}`;
+  const input = `${accountName.toLowerCase()}|${campaign.toLowerCase()}|${adset.toLowerCase()}|${ad.toLowerCase()}`;
   // Use SHA-256 and keep the first 8 bytes (64 bits)
   const hex = createHash('sha256').update(input).digest('hex').slice(0, 16);
   const positive = BigInt('0x' + hex) & ((1n << 63n) - 1n); // 63-bit positive number


### PR DESCRIPTION
## Summary
- handle additional Spanish Meta headers and canonical mappings
- restrict date parsing to ISO or D/M/Y formats only
- track totals rows and persist client currency during Meta imports
- make synthetic ad IDs case-insensitive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a7661f990833298376ab1ed5ce16f