### PR TITLE
Use UUID client identifiers

### DIFF
--- a/scripts/meta-schema.sql
+++ b/scripts/meta-schema.sql
@@ -2,10 +2,11 @@
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'clients') AND type in (N'U'))
 BEGIN
     CREATE TABLE clients (
-        id INT IDENTITY(1,1) PRIMARY KEY,
+        client_id UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID(),
         name NVARCHAR(255) NOT NULL,
         name_norm NVARCHAR(255) NOT NULL UNIQUE,
-        created_at DATETIME DEFAULT GETDATE()
+        created_at DATETIME DEFAULT GETDATE(),
+        CONSTRAINT PK_clients PRIMARY KEY (client_id)
     );
 END;
 GO
@@ -13,7 +14,7 @@ GO
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'facts_meta') AND type in (N'U'))
 BEGIN
     CREATE TABLE facts_meta (
-        client_id INT NOT NULL,
+        client_id UNIQUEIDENTIFIER NOT NULL,
         [date] DATE NOT NULL,
         ad_id NVARCHAR(255) NOT NULL,
         spend DECIMAL(18,2) NULL,
@@ -27,7 +28,7 @@ GO
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'ads') AND type in (N'U'))
 BEGIN
     CREATE TABLE ads (
-        client_id INT NOT NULL,
+        client_id UNIQUEIDENTIFIER NOT NULL,
         ad_id NVARCHAR(255) NOT NULL,
         ad_name_norm NVARCHAR(255) NOT NULL,
         name NVARCHAR(255) NULL,

--- a/server.js
+++ b/server.js
@@ -926,7 +926,7 @@ app.post('/api/sql/import-excel', upload.single('file'), async (req, res) => {
 
         const report = await sqlPool
             .request()
-            .input('client_id', sql.Int, clientId)
+            .input('client_id', sql.UniqueIdentifier, clientId)
             .input('nombre_archivo', sql.VarChar(255), req.file.originalname)
             .input('hash_archivo', sql.Char(64), fileHash)
             .input('period_start', sql.Date, periodStart)

--- a/server/migrations/003_fix_sql_schema.sql
+++ b/server/migrations/003_fix_sql_schema.sql
@@ -55,3 +55,95 @@ IF COL_LENGTH('dbo.facts_meta','ad_id_nz') IS NULL
 -- Índice único (client_id, date, ad_id_nz)
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name='UX_facts_meta_client_date_ad_nz' AND object_id=OBJECT_ID('dbo.facts_meta'))
   CREATE UNIQUE INDEX UX_facts_meta_client_date_ad_nz ON dbo.facts_meta(client_id, [date], ad_id_nz);
+
+-- C) ads: asegurar client_id UNIQUEIDENTIFIER y FK
+IF OBJECT_ID('dbo.ads','U') IS NULL
+BEGIN
+  CREATE TABLE dbo.ads(
+    ad_id BIGINT PRIMARY KEY,
+    client_id UNIQUEIDENTIFIER NOT NULL,
+    name NVARCHAR(255) NULL,
+    ad_name_norm NVARCHAR(255) NULL,
+    ad_preview_link NVARCHAR(MAX) NULL,
+    ad_creative_thumbnail_url NVARCHAR(MAX) NULL,
+    created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT FK_ads_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id)
+  );
+END
+ELSE
+BEGIN
+  IF COL_LENGTH('dbo.ads','client_id') IS NULL
+    ALTER TABLE dbo.ads ADD client_id UNIQUEIDENTIFIER NULL;
+  ALTER TABLE dbo.ads ALTER COLUMN client_id UNIQUEIDENTIFIER NOT NULL;
+  IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name='FK_ads_clients' AND parent_object_id=OBJECT_ID('dbo.ads'))
+    ALTER TABLE dbo.ads ADD CONSTRAINT FK_ads_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id);
+END;
+
+-- D) archivos_reporte: asegurar client_id UNIQUEIDENTIFIER y FK
+IF OBJECT_ID('dbo.archivos_reporte','U') IS NULL
+BEGIN
+  CREATE TABLE dbo.archivos_reporte(
+    id_reporte INT IDENTITY(1,1) PRIMARY KEY,
+    client_id UNIQUEIDENTIFIER NOT NULL,
+    nombre_archivo NVARCHAR(255) NULL,
+    hash_archivo CHAR(64) NOT NULL,
+    period_start DATE NULL,
+    period_end DATE NULL,
+    days_detected INT NULL,
+    uploaded_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT FK_archivos_reporte_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id)
+  );
+END
+ELSE
+BEGIN
+  IF COL_LENGTH('dbo.archivos_reporte','client_id') IS NULL
+    ALTER TABLE dbo.archivos_reporte ADD client_id UNIQUEIDENTIFIER NULL;
+  ALTER TABLE dbo.archivos_reporte ALTER COLUMN client_id UNIQUEIDENTIFIER NOT NULL;
+  IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name='FK_archivos_reporte_clients' AND parent_object_id=OBJECT_ID('dbo.archivos_reporte'))
+    ALTER TABLE dbo.archivos_reporte ADD CONSTRAINT FK_archivos_reporte_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id);
+END;
+
+-- E) archivos_url: asegurar client_id UNIQUEIDENTIFIER y FK
+IF OBJECT_ID('dbo.archivos_url','U') IS NULL
+BEGIN
+  CREATE TABLE dbo.archivos_url(
+    id_url INT IDENTITY(1,1) PRIMARY KEY,
+    client_id UNIQUEIDENTIFIER NOT NULL,
+    nombre_archivo NVARCHAR(255) NULL,
+    hash_archivo CHAR(64) NOT NULL,
+    uploaded_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT FK_archivos_url_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id)
+  );
+END
+ELSE
+BEGIN
+  IF COL_LENGTH('dbo.archivos_url','client_id') IS NULL
+    ALTER TABLE dbo.archivos_url ADD client_id UNIQUEIDENTIFIER NULL;
+  ALTER TABLE dbo.archivos_url ALTER COLUMN client_id UNIQUEIDENTIFIER NOT NULL;
+  IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name='FK_archivos_url_clients' AND parent_object_id=OBJECT_ID('dbo.archivos_url'))
+    ALTER TABLE dbo.archivos_url ADD CONSTRAINT FK_archivos_url_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id);
+END;
+
+-- F) vistas_preview: asegurar client_id UNIQUEIDENTIFIER y FK
+IF OBJECT_ID('dbo.vistas_preview','U') IS NULL
+BEGIN
+  CREATE TABLE dbo.vistas_preview(
+    client_id UNIQUEIDENTIFIER NOT NULL,
+    [Account name] NVARCHAR(255) NULL,
+    [Ad name] NVARCHAR(255) NOT NULL,
+    [Reach] BIGINT NULL,
+    [Ad Preview Link] NVARCHAR(MAX) NULL,
+    [Ad Creative Thumbnail Url] NVARCHAR(MAX) NULL,
+    updated_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT PK_vistas_preview PRIMARY KEY (client_id, [Ad name]),
+    CONSTRAINT FK_vistas_preview_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id)
+  );
+END
+ELSE
+BEGIN
+  IF COL_LENGTH('dbo.vistas_preview','client_id') IS NULL
+    ALTER TABLE dbo.vistas_preview ADD client_id UNIQUEIDENTIFIER NULL;
+  ALTER TABLE dbo.vistas_preview ALTER COLUMN client_id UNIQUEIDENTIFIER NOT NULL;
+  IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name='FK_vistas_preview_clients' AND parent_object_id=OBJECT_ID('dbo.vistas_preview'))
+    ALTER TABLE dbo.vistas_preview ADD CONSTRAINT FK_vistas_preview_clients FOREIGN KEY (client_id) REFERENCES dbo.clients(client_id);
+END;

--- a/sqlTables.js
+++ b/sqlTables.js
@@ -2,7 +2,7 @@ export const TABLES = {
   clients: {
     create: `
         CREATE TABLE clients (
-            client_id INT IDENTITY(1,1) PRIMARY KEY,
+            client_id UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID() PRIMARY KEY,
             name VARCHAR(255) UNIQUE NOT NULL,
             token VARCHAR(255),
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -14,7 +14,7 @@ export const TABLES = {
     create: `
         CREATE TABLE ads (
             ad_id BIGINT PRIMARY KEY,
-            client_id INT NOT NULL,
+            client_id UNIQUEIDENTIFIER NOT NULL,
             ad_name VARCHAR(255),
             ad_preview_link TEXT,
             ad_creative_thumbnail_url TEXT,
@@ -27,7 +27,7 @@ export const TABLES = {
   facts_meta: {
     create: `
         CREATE TABLE facts_meta (
-            client_id INT NOT NULL,
+            client_id UNIQUEIDENTIFIER NOT NULL,
             ad_id BIGINT NOT NULL,
             campaign_id BIGINT,
             adset_id BIGINT,
@@ -48,7 +48,7 @@ export const TABLES = {
     create: `
         CREATE TABLE archivos_reporte (
             id_reporte INT IDENTITY(1,1) PRIMARY KEY,
-            client_id INT NOT NULL,
+            client_id UNIQUEIDENTIFIER NOT NULL,
             nombre_archivo VARCHAR(255),
             hash_archivo CHAR(64) UNIQUE NOT NULL,
             period_start DATE,
@@ -151,7 +151,7 @@ export const TABLES = {
     create: `
         CREATE TABLE archivos_url (
             id_url INT IDENTITY(1,1) PRIMARY KEY,
-            client_id INT NOT NULL,
+            client_id UNIQUEIDENTIFIER NOT NULL,
             nombre_archivo VARCHAR(255),
             hash_archivo CHAR(64) UNIQUE NOT NULL,
             uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -163,7 +163,7 @@ export const TABLES = {
   vistas_preview: {
     create: `
         CREATE TABLE vistas_preview (
-            client_id INT NOT NULL,
+            client_id UNIQUEIDENTIFIER NOT NULL,
             [Account name] VARCHAR(255),
             [Ad name] VARCHAR(255),
             [Reach] BIGINT,


### PR DESCRIPTION
## Summary
- replace integer client identifiers with UNIQUEIDENTIFIER across clients, ads, facts_meta, archivos_reporte, archivos_url and vistas_preview tables
- update server insert logic to send UUID client_ids
- extend meta schema and migrations to convert existing tables and enforce foreign keys

## Testing
- `npm test` *(fails: Failed to resolve import "./lib/parseDateForSort" from "lib/parseDateForSort.test.ts")*

------
https://chatgpt.com/codex/tasks/task_e_689b8464b640833281413240aa6b0e1b