### PR TITLE
Add star schema scripts and sample analytics

### DIFF
--- a/scripts/analytical_queries.sql
+++ b/scripts/analytical_queries.sql
@@ -1,0 +1,59 @@
+-- Resumen Ejecutivo por Campaña
+SELECT
+    c.CampaignName,
+    SUM(f.Spend)        AS TotalSpend,
+    SUM(f.Impressions)  AS TotalImpressions,
+    SUM(f.Clicks)       AS TotalClicks,
+    SUM(f.Purchases)    AS TotalPurchases,
+    CASE WHEN SUM(f.Purchases) > 0 THEN SUM(f.Spend) / SUM(f.Purchases) END AS CostPerPurchase,
+    CASE WHEN SUM(f.Spend) > 0 THEN SUM(f.PurchaseValue) / SUM(f.Spend) END AS ROAS
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Campaigns c ON f.CampaignID = c.CampaignID
+GROUP BY c.CampaignName;
+
+-- Análisis de Rendimiento por Sexo y Edad para CampaignID = 1
+SELECT
+    d.AgeBracket,
+    d.Gender,
+    SUM(f.Spend)     AS TotalSpend,
+    SUM(f.Purchases) AS TotalPurchases,
+    CASE WHEN SUM(f.Purchases) > 0 THEN SUM(f.Spend) / SUM(f.Purchases) END AS CostPerPurchase
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Demographics d ON f.DemographicID = d.DemographicID
+WHERE f.CampaignID = 1
+GROUP BY d.AgeBracket, d.Gender
+ORDER BY d.AgeBracket, d.Gender;
+
+-- Top 5 Anuncios con Mejor Retorno de Inversión (ROAS)
+SELECT TOP 5
+    a.AdName,
+    c.CampaignName,
+    CASE WHEN SUM(f.Spend) > 0 THEN SUM(f.PurchaseValue) / SUM(f.Spend) END AS ROAS
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Ads a ON f.AdID = a.AdID
+JOIN dbo.dim_Campaigns c ON f.CampaignID = c.CampaignID
+GROUP BY a.AdName, c.CampaignName
+ORDER BY ROAS DESC;
+
+-- Evolución Diaria del Gasto vs. Compras (últimos 30 días)
+SELECT
+    d.FullDate,
+    SUM(f.Spend)     AS TotalSpend,
+    SUM(f.Purchases) AS TotalPurchases
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Date d ON f.DateID = d.DateID
+WHERE d.FullDate >= DATEADD(day, -30, CAST(GETDATE() AS DATE))
+GROUP BY d.FullDate
+ORDER BY d.FullDate;
+
+-- Análisis de Rendimiento por Plataforma y Dispositivo
+SELECT
+    p.Platform,
+    p.Device,
+    SUM(f.Spend)     AS TotalSpend,
+    SUM(f.Purchases) AS TotalPurchases,
+    CASE WHEN SUM(f.Clicks) > 0 THEN (SUM(f.Purchases) * 100.0) / SUM(f.Clicks) END AS ConversionRatePct
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Placements p ON f.PlacementID = p.PlacementID
+GROUP BY p.Platform, p.Device
+ORDER BY p.Platform, p.Device;

--- a/scripts/import_meta_csv.py
+++ b/scripts/import_meta_csv.py
@@ -1,0 +1,297 @@
+"""
+Carga incremental de reportes publicitarios a un modelo estrella en SQL Server.
+
+- Lee un archivo CSV (86 columnas) usando pandas.
+- Aplica lógica de "buscar o crear" para las tablas de dimensiones.
+- Elimina la métrica diaria existente y luego inserta la nueva en una sola transacción.
+- Maneja errores por fila, permitiendo continuar con las siguientes.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+import pandas as pd
+import pyodbc
+
+# ---------------------------------------------------------------------------
+# Configuración
+# ---------------------------------------------------------------------------
+SERVER = "localhost\\SQLEXPRESS"
+DATABASE = "MarketingDW"
+USERNAME = "sa"
+PASSWORD = "yourStrong(!)Password"
+CSV_PATH = "reporte.csv"
+
+CONN_STR = (
+    f"DRIVER={{ODBC Driver 17 for SQL Server}};"
+    f"SERVER={SERVER};"
+    f"DATABASE={DATABASE};"
+    f"UID={USERNAME};"
+    f"PWD={PASSWORD};"
+    "TrustServerCertificate=yes;"
+)
+
+
+# ---------------------------------------------------------------------------
+# Funciones auxiliares para UPSERT de dimensiones
+# ---------------------------------------------------------------------------
+def get_or_create_client(cur: pyodbc.Cursor, account_fbid: int, name: str | None) -> int:
+    cur.execute("SELECT ClientID FROM dim_Clients WHERE AccountFBID = ?", account_fbid)
+    row = cur.fetchone()
+    if row:
+        return row.ClientID
+    cur.execute(
+        """
+        INSERT INTO dim_Clients (AccountFBID, ClientName)
+        OUTPUT INSERTED.ClientID
+        VALUES (?, ?)
+        """,
+        account_fbid,
+        name,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_campaign(
+    cur: pyodbc.Cursor, client_id: int, campaign_fbid: int, name: str | None, objective: str | None
+) -> int:
+    cur.execute("SELECT CampaignID FROM dim_Campaigns WHERE CampaignFBID = ?", campaign_fbid)
+    row = cur.fetchone()
+    if row:
+        return row.CampaignID
+    cur.execute(
+        """
+        INSERT INTO dim_Campaigns (ClientID, CampaignFBID, CampaignName, Objective)
+        OUTPUT INSERTED.CampaignID
+        VALUES (?, ?, ?, ?)
+        """,
+        client_id,
+        campaign_fbid,
+        name,
+        objective,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_adset(
+    cur: pyodbc.Cursor, campaign_id: int, adset_fbid: int, name: str | None
+) -> int:
+    cur.execute("SELECT AdSetID FROM dim_AdSets WHERE AdSetFBID = ?", adset_fbid)
+    row = cur.fetchone()
+    if row:
+        return row.AdSetID
+    cur.execute(
+        """
+        INSERT INTO dim_AdSets (CampaignID, AdSetFBID, AdSetName)
+        OUTPUT INSERTED.AdSetID
+        VALUES (?, ?, ?)
+        """,
+        campaign_id,
+        adset_fbid,
+        name,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_ad(
+    cur: pyodbc.Cursor,
+    adset_id: int,
+    ad_fbid: int,
+    name: str | None,
+    body: str | None,
+    thumbnail_url: str | None,
+    permanent_link: str | None,
+) -> int:
+    cur.execute("SELECT AdID FROM dim_Ads WHERE AdFBID = ?", ad_fbid)
+    row = cur.fetchone()
+    if row:
+        return row.AdID
+    cur.execute(
+        """
+        INSERT INTO dim_Ads
+            (AdSetID, AdFBID, AdName, AdBody, AdThumbnailURL, PermanentLink)
+        OUTPUT INSERTED.AdID
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        adset_id,
+        ad_fbid,
+        name,
+        body,
+        thumbnail_url,
+        permanent_link,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_date(cur: pyodbc.Cursor, full_date: datetime) -> int:
+    date_id = int(full_date.strftime("%Y%m%d"))
+    cur.execute("SELECT DateID FROM dim_Date WHERE DateID = ?", date_id)
+    if cur.fetchone():
+        return date_id
+    cur.execute(
+        """
+        INSERT INTO dim_Date (DateID, FullDate, Year, Month, Day, DayOfWeek)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        date_id,
+        full_date.date(),
+        full_date.year,
+        full_date.month,
+        full_date.day,
+        full_date.weekday() + 1,
+    )
+    return date_id
+
+
+def get_or_create_demographic(
+    cur: pyodbc.Cursor, age_bracket: str | None, gender: str | None
+) -> int:
+    cur.execute(
+        "SELECT DemographicID FROM dim_Demographics WHERE AgeBracket = ? AND Gender = ?",
+        age_bracket,
+        gender,
+    )
+    row = cur.fetchone()
+    if row:
+        return row.DemographicID
+    cur.execute(
+        """
+        INSERT INTO dim_Demographics (AgeBracket, Gender)
+        OUTPUT INSERTED.DemographicID
+        VALUES (?, ?)
+        """,
+        age_bracket,
+        gender,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_placement(
+    cur: pyodbc.Cursor, platform: str | None, device: str | None, position: str | None
+) -> int:
+    cur.execute(
+        """
+        SELECT PlacementID FROM dim_Placements
+        WHERE Platform = ? AND Device = ? AND Position = ?
+        """,
+        platform,
+        device,
+        position,
+    )
+    row = cur.fetchone()
+    if row:
+        return row.PlacementID
+    cur.execute(
+        """
+        INSERT INTO dim_Placements (Platform, Device, Position)
+        OUTPUT INSERTED.PlacementID
+        VALUES (?, ?, ?)
+        """,
+        platform,
+        device,
+        position,
+    )
+    return cur.fetchone()[0]
+
+
+# ---------------------------------------------------------------------------
+# Función principal de procesamiento
+# ---------------------------------------------------------------------------
+def process_row(cur: pyodbc.Cursor, row: pd.Series) -> None:
+    date_id = get_or_create_date(cur, row.FullDate)
+    client_id = get_or_create_client(cur, row.AccountFBID, row.ClientName)
+    campaign_id = get_or_create_campaign(cur, client_id, row.CampaignFBID, row.CampaignName, row.Objective)
+    adset_id = get_or_create_adset(cur, campaign_id, row.AdSetFBID, row.AdSetName)
+    ad_id = get_or_create_ad(
+        cur,
+        adset_id,
+        row.AdFBID,
+        row.AdName,
+        row.AdBody,
+        row.AdThumbnailURL,
+        row.PermanentLink,
+    )
+    demographic_id = get_or_create_demographic(cur, row.AgeBracket, row.Gender)
+    placement_id = get_or_create_placement(cur, row.Platform, row.Device, row.Position)
+
+    cur.execute(
+        """
+        DELETE FROM fact_Metrics
+        WHERE DateID=? AND AdID=? AND DemographicID=? AND PlacementID=?
+        """,
+        date_id,
+        ad_id,
+        demographic_id,
+        placement_id,
+    )
+
+    cur.execute(
+        """
+        INSERT INTO fact_Metrics (
+            DateID, ClientID, CampaignID, AdSetID, AdID, DemographicID, PlacementID,
+            Spend, Impressions, Reach, Clicks, Purchases, PurchaseValue,
+            VideoPlays_25_Pct, VideoPlays_50_Pct, VideoPlays_75_Pct,
+            VideoPlays_95_Pct, VideoPlays_100_Pct, Results, CostPerResult
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        date_id,
+        client_id,
+        campaign_id,
+        adset_id,
+        ad_id,
+        demographic_id,
+        placement_id,
+        row.Spend,
+        row.Impressions,
+        row.Reach,
+        row.Clicks,
+        row.Purchases,
+        row.PurchaseValue,
+        row.VideoPlays_25_Pct,
+        row.VideoPlays_50_Pct,
+        row.VideoPlays_75_Pct,
+        row.VideoPlays_95_Pct,
+        row.VideoPlays_100_Pct,
+        row.Results,
+        row.CostPerResult,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Punto de entrada
+# ---------------------------------------------------------------------------
+def main() -> None:
+    print("Conectando a la base de datos...")
+    try:
+        conn = pyodbc.connect(CONN_STR, autocommit=False)
+    except pyodbc.Error as err:
+        print(f"Error de conexión: {err}")
+        sys.exit(1)
+
+    try:
+        df = pd.read_csv(CSV_PATH, parse_dates=["FullDate"])
+    except Exception as err:  # noqa: BLE001
+        print(f"No se pudo leer el CSV: {err}")
+        conn.close()
+        sys.exit(1)
+
+    print(f"Iniciando importación de archivo {CSV_PATH}")
+    cursor = conn.cursor()
+    total = len(df)
+
+    for idx, row in enumerate(df.itertuples(index=False), start=1):
+        print(f"Procesando fila {idx} de {total}...")
+        try:
+            process_row(cursor, row)
+            conn.commit()
+        except pyodbc.Error as err:
+            conn.rollback()
+            print(f"Error en fila {idx}: {err}")
+
+    cursor.close()
+    conn.close()
+    print("Importación completada.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/meta-schema.sql
+++ b/scripts/meta-schema.sql
@@ -1,40 +1,161 @@
--- Idempotent creation of clients and facts_meta tables
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'clients') AND type in (N'U'))
+IF DB_ID('MarketingDW') IS NULL
 BEGIN
-    CREATE TABLE clients (
-        id INT IDENTITY(1,1) PRIMARY KEY,
-        name NVARCHAR(255) NOT NULL,
-        name_norm NVARCHAR(255) NOT NULL UNIQUE,
-        created_at DATETIME DEFAULT GETDATE()
+    CREATE DATABASE MarketingDW;
+END;
+GO
+USE MarketingDW;
+GO
+
+-- ============================================================
+-- Dimensional Tables
+-- ============================================================
+IF OBJECT_ID('dbo.dim_Clients','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_Clients (
+        ClientID    INT IDENTITY(1,1) PRIMARY KEY,
+        AccountFBID BIGINT      NOT NULL,
+        ClientName  NVARCHAR(255)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_dim_Clients_AccountFBID')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_dim_Clients_AccountFBID ON dbo.dim_Clients(AccountFBID);
+END;
+GO
+
+IF OBJECT_ID('dbo.dim_Campaigns','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_Campaigns (
+        CampaignID   INT IDENTITY(1,1) PRIMARY KEY,
+        ClientID     INT         NOT NULL,
+        CampaignFBID BIGINT      NOT NULL,
+        CampaignName NVARCHAR(255),
+        Objective    NVARCHAR(100),
+        CONSTRAINT FK_dim_Campaigns_dim_Clients FOREIGN KEY (ClientID)
+            REFERENCES dbo.dim_Clients(ClientID)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_dim_Campaigns_CampaignFBID')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_dim_Campaigns_CampaignFBID ON dbo.dim_Campaigns(CampaignFBID);
+END;
+GO
+
+IF OBJECT_ID('dbo.dim_AdSets','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_AdSets (
+        AdSetID   INT IDENTITY(1,1) PRIMARY KEY,
+        CampaignID INT        NOT NULL,
+        AdSetFBID  BIGINT     NOT NULL,
+        AdSetName  NVARCHAR(255),
+        CONSTRAINT FK_dim_AdSets_dim_Campaigns FOREIGN KEY (CampaignID)
+            REFERENCES dbo.dim_Campaigns(CampaignID)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_dim_AdSets_AdSetFBID')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_dim_AdSets_AdSetFBID ON dbo.dim_AdSets(AdSetFBID);
+END;
+GO
+
+IF OBJECT_ID('dbo.dim_Ads','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_Ads (
+        AdID           INT IDENTITY(1,1) PRIMARY KEY,
+        AdSetID        INT         NOT NULL,
+        AdFBID         BIGINT      NOT NULL,
+        AdName         NVARCHAR(500),
+        AdBody         NVARCHAR(MAX),
+        AdThumbnailURL NVARCHAR(1024),
+        PermanentLink  NVARCHAR(1024),
+        CONSTRAINT FK_dim_Ads_dim_AdSets FOREIGN KEY (AdSetID)
+            REFERENCES dbo.dim_AdSets(AdSetID)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_dim_Ads_AdFBID')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_dim_Ads_AdFBID ON dbo.dim_Ads(AdFBID);
+END;
+GO
+
+IF OBJECT_ID('dbo.dim_Date','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_Date (
+        DateID    INT      PRIMARY KEY,
+        FullDate  DATE     NOT NULL,
+        Year      SMALLINT,
+        Month     TINYINT,
+        Day       TINYINT,
+        DayOfWeek TINYINT
     );
 END;
 GO
 
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'facts_meta') AND type in (N'U'))
+IF OBJECT_ID('dbo.dim_Demographics','U') IS NULL
 BEGIN
-    CREATE TABLE facts_meta (
-        client_id INT NOT NULL,
-        [date] DATE NOT NULL,
-        ad_id NVARCHAR(255) NOT NULL,
-        spend DECIMAL(18,2) NULL,
-        days_detected INT DEFAULT 0,
-        PRIMARY KEY (client_id, [date], ad_id)
+    CREATE TABLE dbo.dim_Demographics (
+        DemographicID INT IDENTITY(1,1) PRIMARY KEY,
+        AgeBracket    VARCHAR(50),
+        Gender        VARCHAR(50)
     );
-    CREATE UNIQUE INDEX UX_facts_meta_client_date_ad ON facts_meta (client_id, [date], ad_id);
 END;
 GO
 
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'ads') AND type in (N'U'))
+IF OBJECT_ID('dbo.dim_Placements','U') IS NULL
 BEGIN
-    CREATE TABLE ads (
-        client_id INT NOT NULL,
-        ad_id NVARCHAR(255) NOT NULL,
-        ad_name_norm NVARCHAR(255) NOT NULL,
-        name NVARCHAR(255) NULL,
-        ad_preview_link NVARCHAR(MAX) NULL,
-        ad_creative_thumbnail_url NVARCHAR(MAX) NULL,
-        PRIMARY KEY (client_id, ad_id)
+    CREATE TABLE dbo.dim_Placements (
+        PlacementID INT IDENTITY(1,1) PRIMARY KEY,
+        Platform    NVARCHAR(100),
+        Device      NVARCHAR(100),
+        Position    NVARCHAR(100)
     );
-    CREATE UNIQUE INDEX UX_ads_client_name_norm ON ads (client_id, ad_name_norm);
+END;
+GO
+
+-- ============================================================
+-- Fact Table
+-- ============================================================
+IF OBJECT_ID('dbo.fact_Metrics','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.fact_Metrics (
+        MetricID           BIGINT IDENTITY(1,1) PRIMARY KEY,
+        DateID             INT NOT NULL,
+        ClientID           INT NOT NULL,
+        CampaignID         INT NOT NULL,
+        AdSetID            INT NOT NULL,
+        AdID               INT NOT NULL,
+        DemographicID      INT NOT NULL,
+        PlacementID        INT NOT NULL,
+        Spend              DECIMAL(18,4),
+        Impressions        INT,
+        Reach              INT,
+        Clicks             INT,
+        Purchases          INT,
+        PurchaseValue      DECIMAL(18,4),
+        VideoPlays_25_Pct  INT,
+        VideoPlays_50_Pct  INT,
+        VideoPlays_75_Pct  INT,
+        VideoPlays_95_Pct  INT,
+        VideoPlays_100_Pct INT,
+        Results            INT,
+        CostPerResult      DECIMAL(18,4),
+        CONSTRAINT FK_fact_Date        FOREIGN KEY (DateID)        REFERENCES dbo.dim_Date(DateID),
+        CONSTRAINT FK_fact_Client      FOREIGN KEY (ClientID)      REFERENCES dbo.dim_Clients(ClientID),
+        CONSTRAINT FK_fact_Campaign    FOREIGN KEY (CampaignID)    REFERENCES dbo.dim_Campaigns(CampaignID),
+        CONSTRAINT FK_fact_AdSet       FOREIGN KEY (AdSetID)       REFERENCES dbo.dim_AdSets(AdSetID),
+        CONSTRAINT FK_fact_Ad          FOREIGN KEY (AdID)          REFERENCES dbo.dim_Ads(AdID),
+        CONSTRAINT FK_fact_Demographic FOREIGN KEY (DemographicID) REFERENCES dbo.dim_Demographics(DemographicID),
+        CONSTRAINT FK_fact_Placement   FOREIGN KEY (PlacementID)   REFERENCES dbo.dim_Placements(PlacementID)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_factMetrics_Date_Campaign_Ad')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_factMetrics_Date_Campaign_Ad
+        ON dbo.fact_Metrics(DateID, CampaignID, AdID);
 END;
 GO


### PR DESCRIPTION
## Summary
- replace meta-schema SQL with star schema DDL and indexes
- add Python ETL script for incremental CSV loading into star schema
- include example analytical queries demonstrating BI capabilities

## Testing
- `npm test` *(fails: Error: Failed to resolve import "./lib/parseDateForSort" from "lib/parseDateForSort.test.ts". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_689bc159892883328fe634734464aae5