### PR TITLE
Add star schema scripts and sample analytics

### DIFF
--- a/scripts/analytical_queries.sql
+++ b/scripts/analytical_queries.sql
@@ -1,0 +1,59 @@
+-- Resumen Ejecutivo por Campaña
+SELECT
+    c.CampaignName,
+    SUM(f.Spend)        AS TotalSpend,
+    SUM(f.Impressions)  AS TotalImpressions,
+    SUM(f.Clicks)       AS TotalClicks,
+    SUM(f.Purchases)    AS TotalPurchases,
+    CASE WHEN SUM(f.Purchases) > 0 THEN SUM(f.Spend) / SUM(f.Purchases) END AS CostPerPurchase,
+    CASE WHEN SUM(f.Spend) > 0 THEN SUM(f.PurchaseValue) / SUM(f.Spend) END AS ROAS
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Campaigns c ON f.CampaignID = c.CampaignID
+GROUP BY c.CampaignName;
+
+-- Análisis de Rendimiento por Sexo y Edad para CampaignID = 1
+SELECT
+    d.AgeBracket,
+    d.Gender,
+    SUM(f.Spend)     AS TotalSpend,
+    SUM(f.Purchases) AS TotalPurchases,
+    CASE WHEN SUM(f.Purchases) > 0 THEN SUM(f.Spend) / SUM(f.Purchases) END AS CostPerPurchase
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Demographics d ON f.DemographicID = d.DemographicID
+WHERE f.CampaignID = 1
+GROUP BY d.AgeBracket, d.Gender
+ORDER BY d.AgeBracket, d.Gender;
+
+-- Top 5 Anuncios con Mejor Retorno de Inversión (ROAS)
+SELECT TOP 5
+    a.AdName,
+    c.CampaignName,
+    CASE WHEN SUM(f.Spend) > 0 THEN SUM(f.PurchaseValue) / SUM(f.Spend) END AS ROAS
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Ads a ON f.AdID = a.AdID
+JOIN dbo.dim_Campaigns c ON f.CampaignID = c.CampaignID
+GROUP BY a.AdName, c.CampaignName
+ORDER BY ROAS DESC;
+
+-- Evolución Diaria del Gasto vs. Compras (últimos 30 días)
+SELECT
+    d.FullDate,
+    SUM(f.Spend)     AS TotalSpend,
+    SUM(f.Purchases) AS TotalPurchases
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Date d ON f.DateID = d.DateID
+WHERE d.FullDate >= DATEADD(day, -30, CAST(GETDATE() AS DATE))
+GROUP BY d.FullDate
+ORDER BY d.FullDate;
+
+-- Análisis de Rendimiento por Plataforma y Dispositivo
+SELECT
+    p.Platform,
+    p.Device,
+    SUM(f.Spend)     AS TotalSpend,
+    SUM(f.Purchases) AS TotalPurchases,
+    CASE WHEN SUM(f.Clicks) > 0 THEN (SUM(f.Purchases) * 100.0) / SUM(f.Clicks) END AS ConversionRatePct
+FROM dbo.fact_Metrics f
+JOIN dbo.dim_Placements p ON f.PlacementID = p.PlacementID
+GROUP BY p.Platform, p.Device
+ORDER BY p.Platform, p.Device;

--- a/scripts/import_meta_csv.py
+++ b/scripts/import_meta_csv.py
@@ -1,0 +1,297 @@
+"""
+Carga incremental de reportes publicitarios a un modelo estrella en SQL Server.
+
+- Lee un archivo CSV (86 columnas) usando pandas.
+- Aplica lógica de "buscar o crear" para las tablas de dimensiones.
+- Elimina la métrica diaria existente y luego inserta la nueva en una sola transacción.
+- Maneja errores por fila, permitiendo continuar con las siguientes.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+import pandas as pd
+import pyodbc
+
+# ---------------------------------------------------------------------------
+# Configuración
+# ---------------------------------------------------------------------------
+SERVER = "localhost\\SQLEXPRESS"
+DATABASE = "MarketingDW"
+USERNAME = "sa"
+PASSWORD = "yourStrong(!)Password"
+CSV_PATH = "reporte.csv"
+
+CONN_STR = (
+    f"DRIVER={{ODBC Driver 17 for SQL Server}};"
+    f"SERVER={SERVER};"
+    f"DATABASE={DATABASE};"
+    f"UID={USERNAME};"
+    f"PWD={PASSWORD};"
+    "TrustServerCertificate=yes;"
+)
+
+
+# ---------------------------------------------------------------------------
+# Funciones auxiliares para UPSERT de dimensiones
+# ---------------------------------------------------------------------------
+def get_or_create_client(cur: pyodbc.Cursor, account_fbid: int, name: str | None) -> int:
+    cur.execute("SELECT ClientID FROM dim_Clients WHERE AccountFBID = ?", account_fbid)
+    row = cur.fetchone()
+    if row:
+        return row.ClientID
+    cur.execute(
+        """
+        INSERT INTO dim_Clients (AccountFBID, ClientName)
+        OUTPUT INSERTED.ClientID
+        VALUES (?, ?)
+        """,
+        account_fbid,
+        name,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_campaign(
+    cur: pyodbc.Cursor, client_id: int, campaign_fbid: int, name: str | None, objective: str | None
+) -> int:
+    cur.execute("SELECT CampaignID FROM dim_Campaigns WHERE CampaignFBID = ?", campaign_fbid)
+    row = cur.fetchone()
+    if row:
+        return row.CampaignID
+    cur.execute(
+        """
+        INSERT INTO dim_Campaigns (ClientID, CampaignFBID, CampaignName, Objective)
+        OUTPUT INSERTED.CampaignID
+        VALUES (?, ?, ?, ?)
+        """,
+        client_id,
+        campaign_fbid,
+        name,
+        objective,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_adset(
+    cur: pyodbc.Cursor, campaign_id: int, adset_fbid: int, name: str | None
+) -> int:
+    cur.execute("SELECT AdSetID FROM dim_AdSets WHERE AdSetFBID = ?", adset_fbid)
+    row = cur.fetchone()
+    if row:
+        return row.AdSetID
+    cur.execute(
+        """
+        INSERT INTO dim_AdSets (CampaignID, AdSetFBID, AdSetName)
+        OUTPUT INSERTED.AdSetID
+        VALUES (?, ?, ?)
+        """,
+        campaign_id,
+        adset_fbid,
+        name,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_ad(
+    cur: pyodbc.Cursor,
+    adset_id: int,
+    ad_fbid: int,
+    name: str | None,
+    body: str | None,
+    thumbnail_url: str | None,
+    permanent_link: str | None,
+) -> int:
+    cur.execute("SELECT AdID FROM dim_Ads WHERE AdFBID = ?", ad_fbid)
+    row = cur.fetchone()
+    if row:
+        return row.AdID
+    cur.execute(
+        """
+        INSERT INTO dim_Ads
+            (AdSetID, AdFBID, AdName, AdBody, AdThumbnailURL, PermanentLink)
+        OUTPUT INSERTED.AdID
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        adset_id,
+        ad_fbid,
+        name,
+        body,
+        thumbnail_url,
+        permanent_link,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_date(cur: pyodbc.Cursor, full_date: datetime) -> int:
+    date_id = int(full_date.strftime("%Y%m%d"))
+    cur.execute("SELECT DateID FROM dim_Date WHERE DateID = ?", date_id)
+    if cur.fetchone():
+        return date_id
+    cur.execute(
+        """
+        INSERT INTO dim_Date (DateID, FullDate, Year, Month, Day, DayOfWeek)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        date_id,
+        full_date.date(),
+        full_date.year,
+        full_date.month,
+        full_date.day,
+        full_date.weekday() + 1,
+    )
+    return date_id
+
+
+def get_or_create_demographic(
+    cur: pyodbc.Cursor, age_bracket: str | None, gender: str | None
+) -> int:
+    cur.execute(
+        "SELECT DemographicID FROM dim_Demographics WHERE AgeBracket = ? AND Gender = ?",
+        age_bracket,
+        gender,
+    )
+    row = cur.fetchone()
+    if row:
+        return row.DemographicID
+    cur.execute(
+        """
+        INSERT INTO dim_Demographics (AgeBracket, Gender)
+        OUTPUT INSERTED.DemographicID
+        VALUES (?, ?)
+        """,
+        age_bracket,
+        gender,
+    )
+    return cur.fetchone()[0]
+
+
+def get_or_create_placement(
+    cur: pyodbc.Cursor, platform: str | None, device: str | None, position: str | None
+) -> int:
+    cur.execute(
+        """
+        SELECT PlacementID FROM dim_Placements
+        WHERE Platform = ? AND Device = ? AND Position = ?
+        """,
+        platform,
+        device,
+        position,
+    )
+    row = cur.fetchone()
+    if row:
+        return row.PlacementID
+    cur.execute(
+        """
+        INSERT INTO dim_Placements (Platform, Device, Position)
+        OUTPUT INSERTED.PlacementID
+        VALUES (?, ?, ?)
+        """,
+        platform,
+        device,
+        position,
+    )
+    return cur.fetchone()[0]
+
+
+# ---------------------------------------------------------------------------
+# Función principal de procesamiento
+# ---------------------------------------------------------------------------
+def process_row(cur: pyodbc.Cursor, row: pd.Series) -> None:
+    date_id = get_or_create_date(cur, row.FullDate)
+    client_id = get_or_create_client(cur, row.AccountFBID, row.ClientName)
+    campaign_id = get_or_create_campaign(cur, client_id, row.CampaignFBID, row.CampaignName, row.Objective)
+    adset_id = get_or_create_adset(cur, campaign_id, row.AdSetFBID, row.AdSetName)
+    ad_id = get_or_create_ad(
+        cur,
+        adset_id,
+        row.AdFBID,
+        row.AdName,
+        row.AdBody,
+        row.AdThumbnailURL,
+        row.PermanentLink,
+    )
+    demographic_id = get_or_create_demographic(cur, row.AgeBracket, row.Gender)
+    placement_id = get_or_create_placement(cur, row.Platform, row.Device, row.Position)
+
+    cur.execute(
+        """
+        DELETE FROM fact_Metrics
+        WHERE DateID=? AND AdID=? AND DemographicID=? AND PlacementID=?
+        """,
+        date_id,
+        ad_id,
+        demographic_id,
+        placement_id,
+    )
+
+    cur.execute(
+        """
+        INSERT INTO fact_Metrics (
+            DateID, ClientID, CampaignID, AdSetID, AdID, DemographicID, PlacementID,
+            Spend, Impressions, Reach, Clicks, Purchases, PurchaseValue,
+            VideoPlays_25_Pct, VideoPlays_50_Pct, VideoPlays_75_Pct,
+            VideoPlays_95_Pct, VideoPlays_100_Pct, Results, CostPerResult
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        date_id,
+        client_id,
+        campaign_id,
+        adset_id,
+        ad_id,
+        demographic_id,
+        placement_id,
+        row.Spend,
+        row.Impressions,
+        row.Reach,
+        row.Clicks,
+        row.Purchases,
+        row.PurchaseValue,
+        row.VideoPlays_25_Pct,
+        row.VideoPlays_50_Pct,
+        row.VideoPlays_75_Pct,
+        row.VideoPlays_95_Pct,
+        row.VideoPlays_100_Pct,
+        row.Results,
+        row.CostPerResult,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Punto de entrada
+# ---------------------------------------------------------------------------
+def main() -> None:
+    print("Conectando a la base de datos...")
+    try:
+        conn = pyodbc.connect(CONN_STR, autocommit=False)
+    except pyodbc.Error as err:
+        print(f"Error de conexión: {err}")
+        sys.exit(1)
+
+    try:
+        df = pd.read_csv(CSV_PATH, parse_dates=["FullDate"])
+    except Exception as err:  # noqa: BLE001
+        print(f"No se pudo leer el CSV: {err}")
+        conn.close()
+        sys.exit(1)
+
+    print(f"Iniciando importación de archivo {CSV_PATH}")
+    cursor = conn.cursor()
+    total = len(df)
+
+    for idx, row in enumerate(df.itertuples(index=False), start=1):
+        print(f"Procesando fila {idx} de {total}...")
+        try:
+            process_row(cursor, row)
+            conn.commit()
+        except pyodbc.Error as err:
+            conn.rollback()
+            print(f"Error en fila {idx}: {err}")
+
+    cursor.close()
+    conn.close()
+    print("Importación completada.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/meta-schema.sql
+++ b/scripts/meta-schema.sql
@@ -1,40 +1,161 @@
--- Idempotent creation of clients and facts_meta tables
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'clients') AND type in (N'U'))
+IF DB_ID('MarketingDW') IS NULL
 BEGIN
-    CREATE TABLE clients (
-        id INT IDENTITY(1,1) PRIMARY KEY,
-        name NVARCHAR(255) NOT NULL,
-        name_norm NVARCHAR(255) NOT NULL UNIQUE,
-        created_at DATETIME DEFAULT GETDATE()
+    CREATE DATABASE MarketingDW;
+END;
+GO
+USE MarketingDW;
+GO
+
+-- ============================================================
+-- Dimensional Tables
+-- ============================================================
+IF OBJECT_ID('dbo.dim_Clients','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_Clients (
+        ClientID    INT IDENTITY(1,1) PRIMARY KEY,
+        AccountFBID BIGINT      NOT NULL,
+        ClientName  NVARCHAR(255)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_dim_Clients_AccountFBID')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_dim_Clients_AccountFBID ON dbo.dim_Clients(AccountFBID);
+END;
+GO
+
+IF OBJECT_ID('dbo.dim_Campaigns','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_Campaigns (
+        CampaignID   INT IDENTITY(1,1) PRIMARY KEY,
+        ClientID     INT         NOT NULL,
+        CampaignFBID BIGINT      NOT NULL,
+        CampaignName NVARCHAR(255),
+        Objective    NVARCHAR(100),
+        CONSTRAINT FK_dim_Campaigns_dim_Clients FOREIGN KEY (ClientID)
+            REFERENCES dbo.dim_Clients(ClientID)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_dim_Campaigns_CampaignFBID')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_dim_Campaigns_CampaignFBID ON dbo.dim_Campaigns(CampaignFBID);
+END;
+GO
+
+IF OBJECT_ID('dbo.dim_AdSets','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_AdSets (
+        AdSetID   INT IDENTITY(1,1) PRIMARY KEY,
+        CampaignID INT        NOT NULL,
+        AdSetFBID  BIGINT     NOT NULL,
+        AdSetName  NVARCHAR(255),
+        CONSTRAINT FK_dim_AdSets_dim_Campaigns FOREIGN KEY (CampaignID)
+            REFERENCES dbo.dim_Campaigns(CampaignID)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_dim_AdSets_AdSetFBID')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_dim_AdSets_AdSetFBID ON dbo.dim_AdSets(AdSetFBID);
+END;
+GO
+
+IF OBJECT_ID('dbo.dim_Ads','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_Ads (
+        AdID           INT IDENTITY(1,1) PRIMARY KEY,
+        AdSetID        INT         NOT NULL,
+        AdFBID         BIGINT      NOT NULL,
+        AdName         NVARCHAR(500),
+        AdBody         NVARCHAR(MAX),
+        AdThumbnailURL NVARCHAR(1024),
+        PermanentLink  NVARCHAR(1024),
+        CONSTRAINT FK_dim_Ads_dim_AdSets FOREIGN KEY (AdSetID)
+            REFERENCES dbo.dim_AdSets(AdSetID)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_dim_Ads_AdFBID')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_dim_Ads_AdFBID ON dbo.dim_Ads(AdFBID);
+END;
+GO
+
+IF OBJECT_ID('dbo.dim_Date','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.dim_Date (
+        DateID    INT      PRIMARY KEY,
+        FullDate  DATE     NOT NULL,
+        Year      SMALLINT,
+        Month     TINYINT,
+        Day       TINYINT,
+        DayOfWeek TINYINT
     );
 END;
 GO
 
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'facts_meta') AND type in (N'U'))
+IF OBJECT_ID('dbo.dim_Demographics','U') IS NULL
 BEGIN
-    CREATE TABLE facts_meta (
-        client_id INT NOT NULL,
-        [date] DATE NOT NULL,
-        ad_id NVARCHAR(255) NOT NULL,
-        spend DECIMAL(18,2) NULL,
-        days_detected INT DEFAULT 0,
-        PRIMARY KEY (client_id, [date], ad_id)
+    CREATE TABLE dbo.dim_Demographics (
+        DemographicID INT IDENTITY(1,1) PRIMARY KEY,
+        AgeBracket    VARCHAR(50),
+        Gender        VARCHAR(50)
     );
-    CREATE UNIQUE INDEX UX_facts_meta_client_date_ad ON facts_meta (client_id, [date], ad_id);
 END;
 GO
 
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'ads') AND type in (N'U'))
+IF OBJECT_ID('dbo.dim_Placements','U') IS NULL
 BEGIN
-    CREATE TABLE ads (
-        client_id INT NOT NULL,
-        ad_id NVARCHAR(255) NOT NULL,
-        ad_name_norm NVARCHAR(255) NOT NULL,
-        name NVARCHAR(255) NULL,
-        ad_preview_link NVARCHAR(MAX) NULL,
-        ad_creative_thumbnail_url NVARCHAR(MAX) NULL,
-        PRIMARY KEY (client_id, ad_id)
+    CREATE TABLE dbo.dim_Placements (
+        PlacementID INT IDENTITY(1,1) PRIMARY KEY,
+        Platform    NVARCHAR(100),
+        Device      NVARCHAR(100),
+        Position    NVARCHAR(100)
     );
-    CREATE UNIQUE INDEX UX_ads_client_name_norm ON ads (client_id, ad_name_norm);
+END;
+GO
+
+-- ============================================================
+-- Fact Table
+-- ============================================================
+IF OBJECT_ID('dbo.fact_Metrics','U') IS NULL
+BEGIN
+    CREATE TABLE dbo.fact_Metrics (
+        MetricID           BIGINT IDENTITY(1,1) PRIMARY KEY,
+        DateID             INT NOT NULL,
+        ClientID           INT NOT NULL,
+        CampaignID         INT NOT NULL,
+        AdSetID            INT NOT NULL,
+        AdID               INT NOT NULL,
+        DemographicID      INT NOT NULL,
+        PlacementID        INT NOT NULL,
+        Spend              DECIMAL(18,4),
+        Impressions        INT,
+        Reach              INT,
+        Clicks             INT,
+        Purchases          INT,
+        PurchaseValue      DECIMAL(18,4),
+        VideoPlays_25_Pct  INT,
+        VideoPlays_50_Pct  INT,
+        VideoPlays_75_Pct  INT,
+        VideoPlays_95_Pct  INT,
+        VideoPlays_100_Pct INT,
+        Results            INT,
+        CostPerResult      DECIMAL(18,4),
+        CONSTRAINT FK_fact_Date        FOREIGN KEY (DateID)        REFERENCES dbo.dim_Date(DateID),
+        CONSTRAINT FK_fact_Client      FOREIGN KEY (ClientID)      REFERENCES dbo.dim_Clients(ClientID),
+        CONSTRAINT FK_fact_Campaign    FOREIGN KEY (CampaignID)    REFERENCES dbo.dim_Campaigns(CampaignID),
+        CONSTRAINT FK_fact_AdSet       FOREIGN KEY (AdSetID)       REFERENCES dbo.dim_AdSets(AdSetID),
+        CONSTRAINT FK_fact_Ad          FOREIGN KEY (AdID)          REFERENCES dbo.dim_Ads(AdID),
+        CONSTRAINT FK_fact_Demographic FOREIGN KEY (DemographicID) REFERENCES dbo.dim_Demographics(DemographicID),
+        CONSTRAINT FK_fact_Placement   FOREIGN KEY (PlacementID)   REFERENCES dbo.dim_Placements(PlacementID)
+    );
+END;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_factMetrics_Date_Campaign_Ad')
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_factMetrics_Date_Campaign_Ad
+        ON dbo.fact_Metrics(DateID, CampaignID, AdID);
 END;
 GO

--- a/server.js
+++ b/server.js
@@ -1017,8 +1017,8 @@ app.post('/api/sql/import-excel', upload.single('file'), async (req, res) => {
         await sqlPool
             .request()
             .input('source', sql.VarChar(50), 'meta-excel')
-            .input('payload', sql.NVarChar(sql.MAX), JSON.stringify(history))
-            .query('INSERT INTO import_history (source, payload) VALUES (@source, @payload)');
+            .input('batch_data', sql.NVarChar(sql.MAX), JSON.stringify(history))
+            .query('INSERT INTO import_history (source, batch_data) VALUES (@source, @batch_data)');
 
         res.json({ success: true, inserted, updated, skipped, clientName, periodStart, periodEnd });
     } catch (error) {
@@ -1041,8 +1041,8 @@ app.get('/api/sql/import-history', async (req, res) => {
         return res.status(400).json({ success: false, error: 'Not connected' });
     }
     try {
-    const result = await sqlPool.request().query('SELECT payload FROM import_history ORDER BY created_at DESC');
-    const history = result.recordset.map(r => JSON.parse(r.payload));
+    const result = await sqlPool.request().query('SELECT batch_data FROM import_history ORDER BY created_at DESC');
+    const history = result.recordset.map(r => JSON.parse(r.batch_data));
         res.json({ success: true, history });
     } catch (error) {
         logger.error('[Server] Error loading SQL import history:', error);

--- a/sqlTables.js
+++ b/sqlTables.js
@@ -1,218 +1,145 @@
 export const TABLES = {
-  clients: {
+  dim_Clients: {
     create: `
-        CREATE TABLE clients (
-            client_id INT IDENTITY(1,1) PRIMARY KEY,
-            name VARCHAR(255) UNIQUE NOT NULL,
-            token VARCHAR(255),
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-        )
+        IF OBJECT_ID('dim_Clients', 'U') IS NULL
+        CREATE TABLE dim_Clients (
+            ClientID INT IDENTITY(1,1) PRIMARY KEY,
+            AccountFBID BIGINT NOT NULL,
+            ClientName NVARCHAR(255)
+        );
+        CREATE NONCLUSTERED INDEX IX_dim_Clients_AccountFBID ON dim_Clients(AccountFBID);
     `,
     dependencies: []
   },
-  ads: {
+  dim_Campaigns: {
     create: `
-        CREATE TABLE ads (
-            ad_id BIGINT PRIMARY KEY,
-            client_id INT NOT NULL,
-            ad_name VARCHAR(255),
-            ad_preview_link TEXT,
-            ad_creative_thumbnail_url TEXT,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (client_id) REFERENCES clients(client_id)
-        )
+        IF OBJECT_ID('dim_Campaigns', 'U') IS NULL
+        CREATE TABLE dim_Campaigns (
+            CampaignID INT IDENTITY(1,1) PRIMARY KEY,
+            ClientID INT NOT NULL,
+            CampaignFBID BIGINT NOT NULL,
+            CampaignName NVARCHAR(255),
+            Objective NVARCHAR(100),
+            FOREIGN KEY (ClientID) REFERENCES dim_Clients(ClientID)
+        );
+        CREATE NONCLUSTERED INDEX IX_dim_Campaigns_CampaignFBID ON dim_Campaigns(CampaignFBID);
     `,
-    dependencies: ['clients']
+    dependencies: ['dim_Clients']
   },
-  facts_meta: {
+  dim_AdSets: {
     create: `
-        CREATE TABLE facts_meta (
-            client_id INT NOT NULL,
-            ad_id BIGINT NOT NULL,
-            campaign_id BIGINT,
-            adset_id BIGINT,
-            impressions INT,
-            clicks INT,
-            spend DECIMAL(10, 2),
-            purchases INT,
-            roas DECIMAL(10, 4),
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            ad_id_nz BIGINT,
-            FOREIGN KEY (client_id) REFERENCES clients(client_id),
-            FOREIGN KEY (ad_id) REFERENCES ads(ad_id)
-        )
+        IF OBJECT_ID('dim_AdSets', 'U') IS NULL
+        CREATE TABLE dim_AdSets (
+            AdSetID INT IDENTITY(1,1) PRIMARY KEY,
+            CampaignID INT NOT NULL,
+            AdSetFBID BIGINT NOT NULL,
+            AdSetName NVARCHAR(255),
+            FOREIGN KEY (CampaignID) REFERENCES dim_Campaigns(CampaignID)
+        );
+        CREATE NONCLUSTERED INDEX IX_dim_AdSets_AdSetFBID ON dim_AdSets(AdSetFBID);
     `,
-    dependencies: ['clients', 'ads']
+    dependencies: ['dim_Campaigns']
   },
-  archivos_reporte: {
+  dim_Ads: {
     create: `
-        CREATE TABLE archivos_reporte (
-            id_reporte INT IDENTITY(1,1) PRIMARY KEY,
-            client_id INT NOT NULL,
-            nombre_archivo VARCHAR(255),
-            hash_archivo CHAR(64) UNIQUE NOT NULL,
-            period_start DATE,
-            period_end DATE,
-            days_detected INT,
-            uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (client_id) REFERENCES clients(client_id)
-        )
+        IF OBJECT_ID('dim_Ads', 'U') IS NULL
+        CREATE TABLE dim_Ads (
+            AdID INT IDENTITY(1,1) PRIMARY KEY,
+            AdSetID INT NOT NULL,
+            AdFBID BIGINT NOT NULL,
+            AdName NVARCHAR(500),
+            AdBody NVARCHAR(MAX),
+            AdThumbnailURL NVARCHAR(1024),
+            PermanentLink NVARCHAR(1024),
+            FOREIGN KEY (AdSetID) REFERENCES dim_AdSets(AdSetID)
+        );
+        CREATE NONCLUSTERED INDEX IX_dim_Ads_AdFBID ON dim_Ads(AdFBID);
     `,
-    dependencies: ['clients']
+    dependencies: ['dim_AdSets']
   },
-  metricas: {
+  dim_Date: {
     create: `
-        CREATE TABLE metricas (
-            id_metricas BIGINT IDENTITY(1,1) PRIMARY KEY,
-            id_reporte INT NOT NULL,
-            [unique_id] VARCHAR(255) NOT NULL,
-            [nombre_de_la_campaña] VARCHAR(255),
-            [nombre_del_conjunto_de_anuncios] VARCHAR(255),
-            [nombre_del_anuncio] VARCHAR(255),
-            [dia] DATE,
-            [edad] VARCHAR(50),
-            [sexo] VARCHAR(50),
-            [importe_gastado_EUR] DECIMAL(12,2),
-            [entrega_de_la_campaña] VARCHAR(50),
-            [entrega_del_conjunto_de_anuncios] VARCHAR(50),
-            [entrega_del_anuncio] VARCHAR(50),
-            [impresiones] BIGINT,
-            [alcance] BIGINT,
-            [frecuencia] DECIMAL(5,2),
-            [compras] INT,
-            [visitas_a_la_página_de_destino] INT,
-            [clics_todos] INT,
-            [cpm_costo_por_mil_impresiones] DECIMAL(12,2),
-            [ctr_todos] DECIMAL(5,2),
-            [cpc_todos] DECIMAL(12,2),
-            [reproducciones_3s] BIGINT,
-            [pagos_iniciados] INT,
-            [pct_compras_por_visitas_lp] DECIMAL(5,2),
-            [me_gusta_en_facebook] INT,
-            [artículos_agregados_al_carrito] INT,
-            [pagos_iniciados_web] INT,
-            [presupuesto_de_la_campaña] DECIMAL(12,2),
-            [tipo_de_presupuesto_de_la_campaña] VARCHAR(50),
-            [públicos_personalizados_incluidos] TEXT,
-            [públicos_personalizados_excluidos] TEXT,
-            [clics_en_el_enlace] INT,
-            [información_de_pago_agregada] INT,
-            [interacción_con_la_página] INT,
-            [comentarios_de_publicaciones] INT,
-            [interacciones_con_la_publicación] INT,
-            [reacciones_a_publicaciones] INT,
-            [veces_compartidas_publicaciones] INT,
-            [puja] DECIMAL(12,2),
-            [tipo_de_puja] VARCHAR(50),
-            [url_del_sitio_web] TEXT,
-            [ctr_link_click_pct] DECIMAL(5,2),
-            [divisa] VARCHAR(10),
-            [valor_de_conversión_compras] DECIMAL(12,2),
-            [objetivo] VARCHAR(100),
-            [tipo_de_compra] VARCHAR(50),
-            [inicio_del_informe] DATE,
-            [fin_del_informe] DATE,
-            [atencion] INT,
-            [deseo] INT,
-            [interes] INT,
-            [rep_video_25_pct] BIGINT,
-            [rep_video_50_pct] BIGINT,
-            [rep_video_100_pct] BIGINT,
-            [pct_rep_3s_por_impresiones] DECIMAL(5,2),
-            [aov] DECIMAL(12,2),
-            [lp_view_rate] DECIMAL(5,2),
-            [adc_lpv] DECIMAL(12,2),
-            [captura_de_video] INT,
-            [tasa_conv_landing] DECIMAL(5,2),
-            [pct_compras] DECIMAL(5,2),
-            [visualizaciones] INT,
-            [nombre_de_la_imagen] VARCHAR(255),
-            [cvr_link_click] DECIMAL(5,2),
-            [retencion_video_short] DECIMAL(5,2),
-            [retención_de_video] DECIMAL(5,2),
-            [rep_video_75_pct] BIGINT,
-            [rep_video_95_pct] BIGINT,
-            [tiempo_promedio_video] DECIMAL(6,2),
-            [thruplays] INT,
-            [rep_video] INT,
-            [rep_video_2s_unicas] INT,
-            [ctr_unico_enlace_pct] DECIMAL(5,2),
-            [nombre_de_la_cuenta] VARCHAR(255),
-            [impresiones_compras] INT,
-            [captura_video_final] INT,
-            inserted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            UNIQUE (unique_id, id_reporte),
-            FOREIGN KEY (id_reporte) REFERENCES archivos_reporte(id_reporte)
-        )
-    `,
-    dependencies: ['archivos_reporte']
-  },
-  archivos_url: {
-    create: `
-        CREATE TABLE archivos_url (
-            id_url INT IDENTITY(1,1) PRIMARY KEY,
-            client_id INT NOT NULL,
-            nombre_archivo VARCHAR(255),
-            hash_archivo CHAR(64) UNIQUE NOT NULL,
-            uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (client_id) REFERENCES clients(client_id)
-        )
-    `,
-    dependencies: ['clients']
-  },
-  vistas_preview: {
-    create: `
-        CREATE TABLE vistas_preview (
-            client_id INT NOT NULL,
-            [Account name] VARCHAR(255),
-            [Ad name] VARCHAR(255),
-            [Reach] BIGINT,
-            [Ad Preview Link] TEXT,
-            [Ad Creative Thumbnail Url] TEXT,
-            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (client_id, [Ad name]),
-            FOREIGN KEY (client_id) REFERENCES clients(client_id)
-        )
-    `,
-    dependencies: ['clients']
-  },
-  processed_files_hashes: {
-    create: `
-        CREATE TABLE processed_files_hashes (
-            id BIGINT IDENTITY(1,1) PRIMARY KEY,
-            file_hash NVARCHAR(128) NOT NULL,
-            created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
-        )
+        IF OBJECT_ID('dim_Date', 'U') IS NULL
+        CREATE TABLE dim_Date (
+            DateID INT PRIMARY KEY,
+            FullDate DATE NOT NULL,
+            Year SMALLINT,
+            Month TINYINT,
+            Day TINYINT,
+            DayOfWeek TINYINT
+        );
     `,
     dependencies: []
   },
-  _staging_facts: {
+  dim_Demographics: {
     create: `
-        CREATE TABLE _staging_facts (
-            session_id UNIQUEIDENTIFIER NOT NULL,
-            client_id UNIQUEIDENTIFIER NOT NULL,
-            [date] DATE NOT NULL,
-            ad_id NVARCHAR(100),
-            campaign_id NVARCHAR(100),
-            adset_id NVARCHAR(100),
-            impressions BIGINT,
-            clicks BIGINT,
-            spend DECIMAL(18,4),
-            purchases INT,
-            purchase_value DECIMAL(18,4),
-            created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
-        )
+        IF OBJECT_ID('dim_Demographics', 'U') IS NULL
+        CREATE TABLE dim_Demographics (
+            DemographicID INT IDENTITY(1,1) PRIMARY KEY,
+            AgeBracket VARCHAR(50),
+            Gender VARCHAR(50)
+        );
     `,
     dependencies: []
+  },
+  dim_Placements: {
+    create: `
+        IF OBJECT_ID('dim_Placements', 'U') IS NULL
+        CREATE TABLE dim_Placements (
+            PlacementID INT IDENTITY(1,1) PRIMARY KEY,
+            Platform NVARCHAR(100),
+            Device NVARCHAR(100),
+            Position NVARCHAR(100)
+        );
+    `,
+    dependencies: []
+  },
+  fact_Metrics: {
+    create: `
+        IF OBJECT_ID('fact_Metrics', 'U') IS NULL
+        CREATE TABLE fact_Metrics (
+            MetricID BIGINT IDENTITY(1,1) PRIMARY KEY,
+            DateID INT NOT NULL,
+            ClientID INT NOT NULL,
+            CampaignID INT NOT NULL,
+            AdSetID INT NOT NULL,
+            AdID INT NOT NULL,
+            DemographicID INT NOT NULL,
+            PlacementID INT NOT NULL,
+            Spend DECIMAL(18,4),
+            Impressions INT,
+            Reach INT,
+            Clicks INT,
+            Purchases INT,
+            PurchaseValue DECIMAL(18,4),
+            VideoPlays_25_Pct INT,
+            VideoPlays_50_Pct INT,
+            VideoPlays_75_Pct INT,
+            VideoPlays_95_Pct INT,
+            VideoPlays_100_Pct INT,
+            Results INT,
+            CostPerResult DECIMAL(18,4),
+            FOREIGN KEY (DateID) REFERENCES dim_Date(DateID),
+            FOREIGN KEY (ClientID) REFERENCES dim_Clients(ClientID),
+            FOREIGN KEY (CampaignID) REFERENCES dim_Campaigns(CampaignID),
+            FOREIGN KEY (AdSetID) REFERENCES dim_AdSets(AdSetID),
+            FOREIGN KEY (AdID) REFERENCES dim_Ads(AdID),
+            FOREIGN KEY (DemographicID) REFERENCES dim_Demographics(DemographicID),
+            FOREIGN KEY (PlacementID) REFERENCES dim_Placements(PlacementID)
+        );
+        CREATE NONCLUSTERED INDEX IX_factMetrics_Date_Campaign_Ad ON fact_Metrics(DateID, CampaignID, AdID);
+    `,
+    dependencies: ['dim_Clients','dim_Campaigns','dim_AdSets','dim_Ads','dim_Date','dim_Demographics','dim_Placements']
   },
   import_history: {
     create: `
+        IF OBJECT_ID('import_history', 'U') IS NULL
         CREATE TABLE import_history (
             id INT IDENTITY(1,1) PRIMARY KEY,
             source VARCHAR(50) NOT NULL DEFAULT 'sql',
             batch_data NVARCHAR(MAX) NOT NULL,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-        )
+        );
     `,
     dependencies: []
   }


### PR DESCRIPTION
## Summary
- replace meta-schema SQL with star schema DDL and indexes
- add Python ETL script for incremental CSV loading into star schema
- include example analytical queries demonstrating BI capabilities
- fix import history payload column and migrate sqlTables definitions to star schema

## Testing
- `npm test` *(fails: Error: Failed to resolve import "./lib/parseDateForSort" from "lib/parseDateForSort.test.ts". Does the file exist?; TypeError: Cannot read properties of undefined (reading 'split'))*

------
https://chatgpt.com/codex/tasks/task_e_689bc159892883328fe634734464aae5