### PR TITLE
Fix SQL table data operations and cleanup

### DIFF
--- a/components/SqlConnectionPanel.tsx
+++ b/components/SqlConnectionPanel.tsx
@@ -203,9 +203,9 @@ export const SqlConnectionPanel: React.FC = () => {
         setTableOpsLoading(true);
         setMessage('');
         try {
-            await fetchJson('/api/sql/tables', { method: 'DELETE' });
-            setMessage('Tablas eliminadas');
-            setTables([]);
+            const data = await fetchJson('/api/sql/tables', { method: 'DELETE' });
+            setMessage(data?.message || 'Tablas eliminadas');
+            await fetchTables();
         } catch (error) {
             const msg = error instanceof Error ? error.message : String(error);
             setMessage(msg === 'Failed to fetch' ? 'No se pudo conectar con el backend' : msg);


### PR DESCRIPTION
## Summary
- Update SQL data deletion endpoint message and remove legacy init route
- Refresh table list after dropping tables in UI

## Testing
- `npm test` *(fails: Failed to resolve import "./lib/parseDateForSort" in parseDateForSort.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d0004b4833294a184f204246847